### PR TITLE
Fixed use of m4 to generate test code

### DIFF
--- a/nf_test/CMakeLists.txt
+++ b/nf_test/CMakeLists.txt
@@ -4,13 +4,13 @@ SET(CMAKE_VERBOSE_MAKEFILE ON)
 SET(CMAKE_BUILD_TYPE "RelWithDebInfo")
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-IF(NOT MSVC)
-    # Process these files with m4.
-    SET(m4_SOURCES test_get test_put)
-    foreach (f ${m4_SOURCES})      
-    	       GEN_m4(${f})
-    endforeach(f)
-ENDIF()
+
+# Process these files with m4.
+SET(m4_SOURCES test_get test_put)
+foreach (f ${m4_SOURCES})      
+		   GEN_m4(${f})
+endforeach(f)
+
 
 IF (BUILD_F03)
   SET(nf_test_SOURCES


### PR DESCRIPTION
I think this block is required on all systems, or else all future references to test_get and test_put have to be removed. 

Taking out the IF allowed me to get past the configure step using CMAKE in windows. 

I am still not able to correctly compile and link the fortran library though.
