### PR TITLE
Changes to fix compilation with the NAG Fortran compiler.

### DIFF
--- a/fortran/netcdf4_variables.f90
+++ b/fortran/netcdf4_variables.f90
@@ -76,7 +76,8 @@
     endif
     if (present(contiguous)) then
        if (contiguous) then
-          nf90_def_var_oneDim = nf_def_var_chunking(ncid, varid, 1, 0)       
+          chunksizes1(1) = 0
+          nf90_def_var_oneDim = nf_def_var_chunking(ncid, varid, 1, chunksizes1(1:1))       
        endif
     endif
     if (nf90_def_var_oneDim .ne. nf90_noerr) return
@@ -190,7 +191,8 @@
     endif
     if (present(contiguous)) then
        if (contiguous) then
-          nf90_def_var_ManyDims = nf_def_var_chunking(ncid, varid, 1, 0)       
+          chunksizes1(1) = 0
+          nf90_def_var_ManyDims = nf_def_var_chunking(ncid, varid, 1, chunksizes1(1:1))       
        endif
     endif
     if (nf90_def_var_ManyDims .ne. nf90_noerr) return

--- a/nf_test/f90tst_grps.f90
+++ b/nf_test/f90tst_grps.f90
@@ -25,7 +25,7 @@ program f90tst_grps
   integer :: nvars, ngatts, ndims, unlimdimid, file_format
   integer, parameter :: CACHE_NELEMS = 10000, CACHE_SIZE = 1000000
   integer, parameter :: DEFLATE_LEVEL = 4
-  integer (kind = 8), parameter :: TOE_SAN_VALUE = 2147483648_8
+  integer (kind = EightByteInt), parameter :: TOE_SAN_VALUE = 2147483648_EightByteInt
   character (len = *), parameter :: VAR1_NAME = "Payroll"
   character (len = *), parameter :: VAR2_NAME = "Spies"
   character (len = *), parameter :: VAR3_NAME = "Propaganda"

--- a/nf_test/f90tst_vars2.f90
+++ b/nf_test/f90tst_vars2.f90
@@ -27,7 +27,7 @@ program f90tst_vars2
   integer :: nvars, ngatts, ndims, unlimdimid, file_format
   integer :: x, y
   integer, parameter :: DEFLATE_LEVEL = 4
-  integer (kind = 8), parameter :: TOE_SAN_VALUE = 2147483648_8
+  integer (kind = EightByteInt), parameter :: TOE_SAN_VALUE = 2147483648_EightByteInt
   character (len = *), parameter :: VAR1_NAME = "Chon-Ji"
   character (len = *), parameter :: VAR2_NAME = "Tan-Gun"
   character (len = *), parameter :: VAR3_NAME = "Toe-San"
@@ -42,7 +42,7 @@ program f90tst_vars2
   character (len = nf90_max_name) :: name_in
   integer :: endianness_in, deflate_level_in
   logical :: shuffle_in, fletcher32_in, contiguous_in
-  integer (kind = 8) :: toe_san_in
+  integer (kind = EightByteInt) :: toe_san_in
   integer :: cache_size_in, cache_nelems_in, cache_preemption_in
 
   print *, ''

--- a/nf_test/f90tst_vars3.f90
+++ b/nf_test/f90tst_vars3.f90
@@ -29,7 +29,7 @@ program f90tst_vars3
   integer, parameter :: DEFAULT_CACHE_NELEMS = 10000, DEFAULT_CACHE_SIZE = 1000000
   integer, parameter :: DEFAULT_CACHE_PREEMPTION = 22
   integer, parameter :: DEFLATE_LEVEL = 4
-  integer (kind = 8), parameter :: TOE_SAN_VALUE = 2147483648_8
+  integer (kind = EightByteInt), parameter :: TOE_SAN_VALUE = 2147483648_EightByteInt
   character (len = *), parameter :: VAR1_NAME = "Chon-Ji"
   character (len = *), parameter :: VAR2_NAME = "Tan-Gun"
   character (len = *), parameter :: VAR3_NAME = "Toe-San"
@@ -43,7 +43,7 @@ program f90tst_vars3
   character (len = nf90_max_name) :: name_in
   integer :: endianness_in, deflate_level_in
   logical :: shuffle_in, fletcher32_in, contiguous_in
-  integer (kind = 8) :: toe_san_in
+  integer (kind = EightByteInt) :: toe_san_in
   integer :: cache_size_in, cache_nelems_in, cache_preemption_in
 
   print *, ''

--- a/nf_test/test_write.F
+++ b/nf_test/test_write.F
@@ -164,7 +164,7 @@ C           /* tests using scratch file */
         err = nf_def_dim(ncid, 'abc', 8, dimid)
         if (err .ne. 0)
      +      call errore('nf_def_dim: ', err)
-        err = nf_def_var(ncid, 'abc', NF_INT, 0, 0, vid)
+        err = nf_def_var(ncid, 'abc', NF_INT, 0, (/0/), vid)
         if (err .ne. 0)
      +      call errore('nf_def_var: ', err)
         err = nf_put_att_text(ncid, NF_GLOBAL, 'title', len(title), 
@@ -194,7 +194,7 @@ C           /* check scratch file written as expected */
      +      call errori('Unexpected dim name in netCDF ', ncid)
         if (length .ne. 8) 
      +      call errori('Unexpected dim length: ', length)
-        err = nf_get_var1_double(ncid, vid, 0, var)
+        err = nf_get_var1_double(ncid, vid, (/0/), var)
         if (err .ne. 0)
      +      call errore('nf_get_var1_double: ', err)
         if (var .ne. 1.0)


### PR DESCRIPTION
I compiled netcdf-fortran with nagfor 6.0 today, and ran into a few minor hitches, which are partially addressed by these patches.

The NAG compiler does not accept passing scalars to (non-elemental) functions that take arrays, and by default its "kind" numbers have nothing to do with the byte count, so one always has to use the output of functions like "selected_int_kind" to get kind numbers. These were the two things that had to be fixed to get "make check" to pass.

Note that there were a few other changes necessary, which are not addressed by this patch, because they don't represent a problem with netcdf-fortran itself:
1. I built with the autotools system, and I had to patch the generated libtool script to build shared libraries and to get linking to work with -openmp. This is really a limitation of autotools, but it's probably easier to deal with using the CMake system; I haven't tried that yet.
2. I needed two additional flags:
   - **-I${SOURCEDIR}/fortran/** 
     - This is necessary for out-of-source builds because nagfor by default only includes the current working directory, not the directory containing the source file with the "include" statement. Again, the fact that this isn't handled for nagfor is probably an autotools limitation, which may be easier to work around (or work by default) with CMake.
   - **-wmismatch=nf_def_var,nf_def_var_fill,nf_inq_var_fill,ncagt,ncapt,ncvgt,ncvpt,ncvgt1,ncvpt1** 
     - This is necessary because these functions are intended to work for inputs of different TKR, but Fortran doesn't allow this (well, until the 2012 TS for C interoperability, but that's not widely implemented).
