### PR TITLE
Removed identifier separator in nf_logging.F90

### DIFF
--- a/fortran/nf_logging.F90
+++ b/fortran/nf_logging.F90
@@ -9,7 +9,7 @@
 
  Integer, Intent(IN) :: new_level
 
- Integer,            :: status
+ Integer             :: status
 
  Integer(C_INT) :: cnew_level, cstatus
 


### PR DESCRIPTION
Certain compilers (intel), does not allow putting a separator without having any identifiers.