### PR TITLE
Add module_tests.F90 to tst03_f77_v2 sources; Drop using_pgi test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -391,13 +391,6 @@ case "$CPPFLAGS" in
       esac
 esac
 
-case "$FC" in
-pgf95|pgf90|pgf77|ifort*|lf90|lf95) using_pgi=yes ;;
-*) ;;
-esac
-
-AM_CONDITIONAL(USING_PGI, [test "x$using_pgi" = "xyes"])
-
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 

--- a/nf03_test/CMakeLists.txt
+++ b/nf03_test/CMakeLists.txt
@@ -71,15 +71,12 @@ LIST(APPEND CLEANFILES tests.mod)
 SET(EXTRA_DIST test03_get.F test03_put.F fills.cdl create_fills.sh run_f77_par_test.sh)
 
 # Did the user build the V2 F77 API? If so, run this test.
-# This fails with pgifortran, but works with gfortran.
-IF(NOT USING_PGI)
-  IF(BUILD_V2)
-    LIST(APPEND check_PROGRAMS tst03_f77_v2)
-    LIST(APPEND TESTS tst03_f77_v2)
-    LIST(APPEND CLEANFILES tst_f77_v2.nc)
-    SET(tst03_f77_v2_SOURCES tst03_f77_v2.F)
-  ENDIF(BUILD_V2)
-ENDIF(NOT USING_PGI)
+IF(BUILD_V2)
+  LIST(APPEND check_PROGRAMS tst03_f77_v2)
+  LIST(APPEND TESTS tst03_f77_v2)
+  LIST(APPEND CLEANFILES tst_f77_v2.nc)
+  SET(tst03_f77_v2_SOURCES module_tests.F90 tst03_f77_v2.F)
+ENDIF(BUILD_V2)
 
 # Need a copy of ref_fills.nc for ftest
 execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/nf_test/ref_fills.nc ${CMAKE_CURRENT_BINARY_DIR}/fills.nc)

--- a/nf03_test/Makefile.am
+++ b/nf03_test/Makefile.am
@@ -110,12 +110,9 @@ run_f77_par_test.sh CMakeLists.txt
 test: check
 
 # Did the user build the V2 F77 API? If so, run this test.
-# This fails with pgifortran, but works with gfortran.
-if !USING_PGI
 if BUILD_V2
 check_PROGRAMS += tst03_f77_v2
 TESTS += tst03_f77_v2
 CLEANFILES += tst_f77_v2.nc temp.tmp
-tst03_f77_v2_SOURCES = tst03_f77_v2.F
+tst03_f77_v2_SOURCES = module_tests.F90 tst03_f77_v2.F
 endif # BUILD_V2
-endif !USING_PGI


### PR DESCRIPTION
I believe the only reason the tst03_f77_v2 test failed to build with PGI was that it was being picky about needed to link to the module_tests object file.  Adding that to the build allows it to compile with PGI for me.