### PR TITLE
USE_LOGGING not propagated to LOGGING preprocessor macro

### DIFF
--- a/fortran/nf_logging.F90
+++ b/fortran/nf_logging.F90
@@ -1,5 +1,3 @@
-#ifdef LOGGING
-
 ! Function to turn on logging
 
 ! Written by: Richard Weed, Ph.D.
@@ -52,5 +50,3 @@ End Interface
  status = cstatus
 
 End Function nf_set_log_level
-
-#endif


### PR DESCRIPTION
If USE_LOGGING=ON this is not propagated to a -DLOGGING compile line definition, which always results in an empty nf_logging.F90 file. (The NAG compiler refuses to accept an empty file.)  This commit addresses this by simply removing the #ifdef from nf_logging.F90; it seems to be unnecessary because both the cmake and autoconf configurations seem to be very careful about only including this source file when USE_LOGGING is ON.
