### PR TITLE
Avoid compilation failure with -Werror=implicit-function-declaration

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -350,6 +350,7 @@ EOF
     for ctype in $2; do
 	AC_MSG_CHECKING(if Fortran \"$1\" is C \"$ctype\")
 	cat >conftest.c <<EOF
+            #include <stdlib.h>
 	    void $FCALLSCSUB(values)
 		$ctype values[[4]];
 	    {


### PR DESCRIPTION
Fedora rawhide no builds everything with -Werror=implicit-function-declaration which causes this check to fail due to implicit declaration of exit().