### PR TITLE
CMakeLists.txt: check for the C types that match Fortran ones.

### DIFF
--- a/CMakeExtras/Makefile.am
+++ b/CMakeExtras/Makefile.am
@@ -1,1 +1,1 @@
-EXTRA_DIST = sizeof_ptrdiff_t.c test_c_ptrdiff_t.f90
+EXTRA_DIST = sizeof_ptrdiff_t.c test_c_ptrdiff_t.f90 MatchNetCDFFortranTypes.cmake

--- a/CMakeExtras/MatchNetCDFFortranTypes.cmake
+++ b/CMakeExtras/MatchNetCDFFortranTypes.cmake
@@ -1,0 +1,67 @@
+# Do tests to determine which Fortran types correspond to NCBYTE, NCSHORT, ...
+# The configure file got these by testing an F77 program, invoking
+# UD_FORTRAN_TYPES defined in acinclude.m4. 
+
+#NOTE: this code is included by both pnetcdf AND netcdf-fortran.  Make sure to test both if you change it.
+
+# check sizes of C types
+check_type_size(int SIZEOF_INT)
+check_type_size(long SIZEOF_LONG)
+check_type_size(float SIZEOF_FLOAT)
+check_type_size(double SIZEOF_DOUBLE)
+check_type_size("signed char" SIZEOF_SIGNED_CHAR)  
+check_type_size(short SIZEOF_SHORT)
+
+# The automake script got all paranoid and checked many different Fortran types to see if they exist
+# I feel like we can assume that the standard types exist.
+SET(NCBYTE_T "byte") # 1 byte
+SET(NCSHORT_T "integer*2") # 2 bytes
+SET(NF_INT1_T "integer*1") # 1 byte
+SET(NF_INT2_T "integer*2") # 2 bytes
+
+# Checks the provided C types to see which ones have the number of bytes passed
+# Roughly equivalent to the Automake function UD_CHECK_CTYPE_FORTRAN
+# creates the result variable: NF_<RESULT_PREFIX>_IS_C_<INT,SHORT,LONG,etc.>.  This is the format accepted by config.h.in.
+macro(find_c_type_with_size SIZE RESULT_PREFIX) # 3rd arg: C types to check
+set(FOUNDANY FALSE)
+foreach(CTYPE ${ARGN})
+  # figure out type part of variable name
+  string(TOUPPER ${CTYPE} CTYPE_VAR_NAME)
+  string(REPLACE " " "_" CTYPE_VAR_NAME ${CTYPE_VAR_NAME})
+  
+  set(RESULT_VAR_NAME NF_${RESULT_PREFIX}_IS_C_${CTYPE_VAR_NAME})
+  
+  # now check the sizes
+  if((NOT FOUNDANY) AND ${SIZEOF_${CTYPE_VAR_NAME}} EQUAL ${SIZE})
+    set(${RESULT_VAR_NAME} TRUE)
+  else()
+    set(${RESULT_VAR_NAME} FALSE)
+  endif()
+  
+  #message("${RESULT_VAR_NAME}: ${${RESULT_VAR_NAME}}")
+
+  if(${RESULT_VAR_NAME})
+    set(FOUNDANY TRUE)
+    break()
+  endif()
+  
+endforeach()
+
+if(NOT FOUNDANY)
+  message(FATAL_ERROR "Unable to find a C ${RESULT_PREFIX} equivalent type with ${SIZE} bytes. \
+You might want to check your compilers to make sure they work.  To ignore the problem, turn off ENABLE_FORTRAN_TYPE_CHECKS.")
+endif()
+
+unset(FOUNDANY)
+
+endmacro(find_c_type_with_size)
+
+message("Matching Fortran types to C types")
+
+find_c_type_with_size(1 INT1 "signed char" short int long)
+find_c_type_with_size(2 INT2 short int long)
+find_c_type_with_size(4 INT int long)
+find_c_type_with_size(4 REAL float double)
+find_c_type_with_size(8 DOUBLEPRECISION float double)
+
+message("Matching Fortran types to C types - done")

--- a/CMakeExtras/MatchNetCDFFortranTypes.cmake
+++ b/CMakeExtras/MatchNetCDFFortranTypes.cmake
@@ -2,8 +2,6 @@
 # The configure file got these by testing an F77 program, invoking
 # UD_FORTRAN_TYPES defined in acinclude.m4. 
 
-#NOTE: this code is included by both pnetcdf AND netcdf-fortran.  Make sure to test both if you change it.
-
 # check sizes of C types
 check_type_size(int SIZEOF_INT)
 check_type_size(long SIZEOF_LONG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,7 +607,7 @@ endif()
 IF(USE_NETCDF_V2)
   SET(BUILD_V2 ON CACHE BOOL "")
 ENDIF()
-# Turn this on by default when it's working
+
 OPTION(ENABLE_FORTRAN_TYPE_CHECKS
   "Determine Fortran types corresponding to netCDF types" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,14 +83,14 @@ IF(MSVC)
 ENDIF()
 
 # auto-configure style checks, other CMake modules.
-INCLUDE (${CMAKE_ROOT}/Modules/CheckLibraryExists.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/CheckTypeSize.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/CheckFunctionExists.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/CheckCXXSourceCompiles.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/CheckSymbolExists.cmake)
-INCLUDE (${CMAKE_ROOT}/Modules/GetPrerequisites.cmake)
+INCLUDE (CheckLibraryExists)
+INCLUDE (CheckIncludeFile)
+INCLUDE (CheckTypeSize)
+INCLUDE (CheckFunctionExists)
+INCLUDE (CheckCXXSourceCompiles)
+INCLUDE (TestBigEndian)
+INCLUDE (CheckSymbolExists)
+INCLUDE (GetPrerequisites)
 FIND_PACKAGE(PkgConfig QUIET)
 
 # Enable 'dist and distcheck'.
@@ -397,7 +397,7 @@ ENDIF()
 ###
 
 IF(NOT netCDF_LIBRARIES AND NOT netCDF_INCLUDE_DIR)
-  FIND_PACKAGE(netCDF QUIET)
+  FIND_PACKAGE(netCDF)
 ELSE()
   SET(netCDF_FOUND TRUE)
 ENDIF()
@@ -609,7 +609,7 @@ IF(USE_NETCDF_V2)
 ENDIF()
 # Turn this on by default when it's working
 OPTION(ENABLE_FORTRAN_TYPE_CHECKS
-  "Determine Fortran types corresponding to netCDF types" OFF)
+  "Determine Fortran types corresponding to netCDF types" ON)
 
 # Toggle whether or not to run tests.
 OPTION(ENABLE_TESTS "Enable netcdf-fortran tests." ON)
@@ -622,8 +622,9 @@ SET(BUILD_F03 "OFF")
 IF(ENABLE_FORTRAN_TYPE_CHECKS)
   # Do tests to determine which Fortran types correspond to NCBYTE, NCSHORT, ...
   # The configure file got these by testing an F77 program, invoking
-  # UD_FORTRAN_TYPES defined in acinclude.m4.  TODO: check the types
-  # from the test program instead of assuming these defaults.
+  # UD_FORTRAN_TYPES defined in acinclude.m4.
+  
+  INCLUDE(CMakeExtras/MatchNetCDFFortranTypes.cmake)
 ELSE()
   # Set Fortran types to default.
   SET(NCBYTE_T "byte")


### PR DESCRIPTION
When I was integrating netcdf-fortran into Amber-MD's build system, I noticed that the `ENABLE_FORTRAN_TYPE_CHECKS` block in CMakeLists.txt (which seems important for portability) was marked as TODO.  Since my CMake-ized PNetcdf also needed this feature, I wrote it for you guys.  I have tested it on several machines and it seems to work fine.

I also made two other small changes to CMakeLists.txt: I removed the unnecessary full include paths to standard library modules, and I removed QUIET from the `find_package(netCDF)` call.  This makes it so the user gets a lot more information if it can't find netcdf.

Let me know if you have any questions or concerns.