### PR TITLE
check error string for prefix 'Unknown Error' only

### DIFF
--- a/nf_test/test_read.F
+++ b/nf_test/test_read.F
@@ -80,7 +80,7 @@ C
 
 C       /* Try on a bad error status */
         message = nf_strerror(-666)!/* should fail */
-        if (message .ne. 'Unknown Error')
+        if (message(1:13) .ne. 'Unknown Error')
      +      call errorc('nf_strerror on bad error status returned: ',
      +          message)
 


### PR DESCRIPTION
PnetCDF error message for unknown error is "Unknown Error: Unrecognized error code -666".
This PR changes the comparison for prefix "Unknown Error" only.