### PR TITLE
consistent error out for nf_test.F and nf03_test.F

### DIFF
--- a/nf03_test/nf03_error.F
+++ b/nf03_test/nf03_error.F
@@ -70,6 +70,5 @@ C
         character*(*)   msg
         integer         err
 
-        nfails = nfails + 1
         call errorc(msg, nf_strerror(err))
         end

--- a/nf03_test/nf03_test.F
+++ b/nf03_test/nf03_test.F
@@ -24,6 +24,8 @@ C $Id: nf_test.F,v 1.28 2009/01/25 14:33:44 ed Exp $
             print *, ' '
             print *, '  ### ', nfails, ' FAILURES TESTING ', name, 
      +               '! ###'
+C           continue the remaining tests, uncomment below to stop now
+C           stop 2
         end if
         end
 

--- a/nf_test/nf_error.F
+++ b/nf_test/nf_error.F
@@ -70,6 +70,5 @@ C
         integer         err
 #include "tests.inc"
 
-        nfails = nfails + 1
         call errorc(msg, nf_strerror(err))
         end

--- a/nf_test/nf_test.F
+++ b/nf_test/nf_test.F
@@ -22,7 +22,8 @@ C $Id: nf_test.F,v 1.29 2009/09/01 16:56:46 ed Exp $
             print *, ' '
             print *, '  ### ', nfails, ' FAILURES TESTING ', name,
      +               '! ###'
-        call EXIT
+C           continue the remaining tests, uncomment below to stop now
+C           stop 2
         end if
 
         end


### PR DESCRIPTION
Currently nf_test.F fails to return an error status for "make check" to catch.

In errore(), increasing nfails is redundent, as it calls errorc().
