### PR TITLE
Fix use of diskless in Fortran test.

### DIFF
--- a/nf03_test/f03tst_open_mem.F
+++ b/nf03_test/f03tst_open_mem.F
@@ -122,7 +122,7 @@ C then call nf_open_mem in NF_DISKLESS mode
         Read(7, iostat=iostat) memfile(1:ncsize)
         If (iostat == 0) then
            Close(7)
-           mode = IOR(NF_DISKLESS, NF_INMEMORY)
+           mode = NF_DISKLESS
            retval = nf_open_mem(FILE_NAME, mode, ncsize, memfile, ncid)
         Else
            retval = iostat


### PR DESCRIPTION
The changes being made to the netcdf-c library
(see https://github.com/Unidata/netcdf-c/issues/1154)
caused the diskless testing in fortran to fail.

This should fix that.