### PR TITLE
fixed configure.ac for static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,7 +339,6 @@ AC_ARG_WITH([temp-large],
             [TEMP_LARGE=$with_temp_large])
 TEMP_LARGE=${TEMP_LARGE-.}
 AC_MSG_RESULT($TEMP_LARGE)
-#AC_SUBST(TEMP_LARGE)
 AC_DEFINE_UNQUOTED([TEMP_LARGE], ["$TEMP_LARGE"], [Place to put very large netCDF test files.])
 
 
@@ -373,10 +372,6 @@ if test "x$nc_build_f90" = xyes; then
      AX_F90_MODULE_FLAG
      AC_SUBST(MOD_FLAG, ${ax_cv_f90_modflag})
    fi
-
-   # Set the FCLIBS flag to help with shared libraries.
-#   AC_FC_LIBRARY_LDFLAGS
-#   AC_F77_LIBRARY_LDFLAGS
 fi
 
 AM_CONDITIONAL(BUILD_F03, [test "x$nc_build_f03" = xyes])
@@ -433,15 +428,6 @@ esac
 # Check to see if any macros must be set to enable large (>2GB) files.
 AC_SYS_LARGEFILE
 
-#AC_MSG_NOTICE([displaying some results])
-
-## This next macro just prints some results for debugging
-## support issues.
-#UD_DISPLAY_RESULTS
-
-# For nightly build testing, output CC, FC, etc.
-#echo "CPPFLAGS=$CPPFLAGS CC=$CC CFLAGS=$CFLAGS CXX=$CXX CXXFLAGS=$CXXFLAGS FC=$FC FCFLAGS=$FCFLAGS F77=$F77 FFLAGS=$FFLAGS LDFLAGS=$LDFLAGS LIBS=$LIBS FLIBS=$FLIBS F90LIBS=$F90LIBS" >> comps.txt
-
 ac_cv_prog_f90_uppercase_mod=no
 
 # This will test the f77 compiler, as well as check some fortran types.
@@ -496,17 +482,22 @@ fi
 
 AC_MSG_NOTICE([checking types, headers, and functions])
 
+# We must check for all these, because they may be used by the netCDF
+# C library.
+AC_CHECK_LIB([m], [floor], [], [])
+AC_CHECK_LIB([curl], [curl_easy_setopt], [], [])
+AC_SEARCH_LIBS([deflate], [zlibwapi zlibstat zlib zlib1 z], [], [])
+AC_SEARCH_LIBS([SZ_Compress], [szip sz], [], [])
+AC_SEARCH_LIBS([dlopen], [dl dld], [], [])
+AC_SEARCH_LIBS([H5Fflush], [hdf5dll hdf5], [], [])
+AC_SEARCH_LIBS([H5DSis_scale], [hdf5_hldll hdf5_hl], [], [])
+
 # Find the netCDF header and library.
 AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([netcdf.h could not be found. Please set CPPFLAGS.])])
 AC_SEARCH_LIBS([nc_open], [netcdf])
 
-# See if various libraries are available
+# See if various functions are available
 AC_CHECK_FUNCS([nc_def_opaque nccreate nc_set_log_level oc_open])
-#test "x$ac_cv_func_oc_open" = xyes && nc_has_dap=yes || nc_has_dap=no
-# Whether we build/test some functionality depends on what we found in
-# the C library.
-#nc_build_v2=$ac_cv_func_nccreate
-#nc_build_v4=$ac_cv_func_nc_def_opaque
 
 nc_build_v2=no
 nc_build_v4=no
@@ -518,14 +509,15 @@ test "x$ac_cv_func_nccreate" = xyes && nc_build_v2=yes
 test "x$ac_cv_func_nc_set_log_level" = xyes && nc_has_logging=yes
 test "x$ac_cv_func_oc_open" = xyes && nc_has_dap=yes
 
-#AC_CHECK_FUNC([nc_def_opaque],[nc_build_v4=yes])
-#AC_CHECK_FUNC([nccreate],[nc_build_v2=yes])
-#AC_CHECK_FUNC([nc_set_log_level],[nc_has_logging=yes])
-#AC_CHECK_FUNC([oc_open],[nc_has_dap=yes])
-
 if test "x$nc_build_v4" = xyes; then
    AC_DEFINE([USE_NETCDF4], [1], [if true, build netCDF-4])
 fi
+
+if test "x$nc_has_logging" = xyes; then
+   AC_DEFINE([LOGGING], [1], [if true, C library contains logging])
+fi
+AC_MSG_CHECKING([netCDF logging present])
+AC_MSG_RESULT([$nc_has_logging])
 
 AC_MSG_CHECKING([netCDF v2 API present])
 AC_MSG_RESULT([$nc_build_v2])
@@ -542,7 +534,6 @@ AM_CONDITIONAL([BUILD_PARALLEL], [test "x$nc_has_pnetcdf" = xyes -o "x$nc_has_pa
 AC_CHECK_HEADER(stdlib.h, ,AC_DEFINE([NO_STDLIB_H], [], [no stdlib.h]))
 AC_CHECK_HEADER(sys/types.h, ,AC_DEFINE([NO_SYS_TYPES_H], [], [no sys_types.h]))
 AC_CHECK_HEADERS([sys/param.h])
-#AC_CHECK_HEADERS([locale.h])
 AC_CHECK_HEADERS([locale.h stdio.h stdarg.h errno.h ctype.h fcntl.h malloc.h stdlib.h string.h \
 			   strings.h unistd.h sys/stat.h getopt.h sys/time.h sys/resource.h])
 AC_HEADER_DIRENT

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -216,16 +216,13 @@ if USE_LOGGING
 	echo '      external nf_set_log_level' >> netcdf.inc
 endif
 
-# The nfconfig.in file is turned into nfconfig.inc by the configure
-# script. The man page is generated on the developers machine for the dist
-EXTRA_DIST += netcdf.inc netcdf2.inc netcdf3.inc netcdf4.inc
+EXTRA_DIST += netcdf2.inc netcdf3.inc netcdf4.inc
 
-DISTCLEANFILES += nfconfig1.inc nfconfig.inc netcdf.inc
-
-CLEANFILES += netcdf_nc_data.mod netcdf_nc_interfaces.mod netcdf_nf_data.mod \
-              netcdf_nf_interfaces.mod netcdf_fortv2_c_interfaces.mod \
-              netcdf_f03.mod netcdf4_nc_interfaces.mod \
-              netcdf4_nf_interfaces.mod netcdf4_f03.mod
+CLEANFILES += netcdf_nc_data.mod netcdf_nc_interfaces.mod		\
+netcdf_nf_data.mod netcdf_nf_interfaces.mod				\
+netcdf_fortv2_c_interfaces.mod netcdf_f03.mod				\
+netcdf4_nc_interfaces.mod netcdf4_nf_interfaces.mod netcdf4_f03.mod	\
+nfconfig.inc netcdf.inc
 
 CLEANFILES += $(UCHEADERS) $(UCCOMMON) $(LCHEADERS) $(LCCOMMON)
 

--- a/libsrc/Makefile.am
+++ b/libsrc/Makefile.am
@@ -33,29 +33,6 @@ if USE_NETCDF4
 libnetcdfc_la_SOURCES += fort-nc4.c
 endif
 
-## The include file and man page are both built by make.
-#BUILT_SOURCES = netcdf.inc
-#
-#netcdf.inc: netcdf2.inc netcdf3.inc netcdf4.inc nfconfig.inc
-#	echo '!     NetCDF-3.' > netcdf.inc
-#	cat @top_srcdir@/fortran/netcdf3.inc >> netcdf.inc
-#if BUILD_V2
-#	echo >> netcdf.inc
-#	echo '!     NetCDF-2.' >> netcdf.inc
-#	cat @top_srcdir@/fortran/netcdf2.inc >> netcdf.inc
-#endif
-#if USE_NETCDF4
-#	echo >> netcdf.inc
-#	echo '!     NetCDF-4.' >> netcdf.inc
-#	cat @top_srcdir@/fortran/netcdf4.inc >> netcdf.inc
-#endif
-#if USE_LOGGING
-#	echo >> netcdf.inc
-#	echo '!     This is to turn on netCDF internal logging.' >> netcdf.inc
-#	echo '      integer nf_set_log_level' >> netcdf.inc
-#	echo '      external nf_set_log_level' >> netcdf.inc
-#endif
-
 # The F77 API man page.
 man_MANS = netcdf_f77.3
 

--- a/libsrc/nfconfig.in
+++ b/libsrc/nfconfig.in
@@ -6,6 +6,7 @@
 #undef NF_HAS_PARALLEL4
 #undef NF_HAS_PNETCDF
 #undef ENABLE_CDF5
+#undef LOGGING
 
 #ifndef UD_NETCDF_CPP_INC
 #define UD_NETCDF_CPP_INC


### PR DESCRIPTION
Fixes #101..
Fixes#103.

Fixes for configure.ac to get static builds working.

Also now correctly cleaning netcdf.inc with make clean.