### PR TITLE
Add filter support to the netcdf-fortram API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,9 @@ OPTION(ENABLE_FORTRAN_TYPE_CHECKS
 # Toggle whether or not to run tests.
 OPTION(ENABLE_TESTS "Enable netcdf-fortran tests." ON)
 
+# Enable filter testing
+OPTION(ENABLE_FILTER_TEST "Enable filter test." OFF)
+
 # Set the default fortran builds; default is to build f03
 SET(BUILD_F90 "ON")
 SET(BUILD_V2 "ON")

--- a/configure.ac
+++ b/configure.ac
@@ -108,10 +108,12 @@ AM_CONDITIONAL(EXTRA_TESTS, [test x$enable_extra_tests = xyes])
 #####
 # Determine if we want to enable doxygen-generated documentation.
 #####
+AC_MSG_CHECKING([whether netCDF documentation should be generated)])
 AC_ARG_ENABLE([doxygen],
 	[AS_HELP_STRING([--enable-doxygen],
 	[Enable generation of documentation with doxygen.])])
-    test "x$enable_doxygen" = xyes || enable_doxygen=no
+test "x$enable_doxygen" = xyes || enable_doxygen=no
+AC_MSG_RESULT($enable_doxygen)
 AM_CONDITIONAL([BUILD_DOCS], [test "x$enable_doxygen" = xyes])
 
 # Does the user want to generate dot-based documentation?
@@ -513,7 +515,8 @@ nc_build_v4=no
 nc_has_logging=no
 nc_has_dap=no
 
-test "x$ac_cv_func_nc_def_opaque" = xyes && nc_build_v4=yes
+AC_CHECK_FUNCS([nc_def_opaque],[nc_build_v4=yes],[nc_build_v4=no])
+#test "x$ac_cv_func_nc_def_opaque" = xyes && nc_build_v4=yes
 test "x$ac_cv_func_nccreate" = xyes && nc_build_v2=yes
 test "x$ac_cv_func_nc_set_log_level" = xyes && nc_has_logging=yes
 test "x$ac_cv_func_oc_open" = xyes && nc_has_dap=yes
@@ -532,6 +535,13 @@ AC_MSG_RESULT([$nc_build_v2])
 AC_MSG_CHECKING([netCDF-4 present])
 AC_MSG_RESULT([$nc_build_v4])
 
+AC_MSG_CHECKING([whether to test the filter API])
+AC_ARG_ENABLE([filter-test],
+              [AS_HELP_STRING([--enable-filter-test],
+                              [Run filter tests: requires access to the plugins directory in a netcdf-c build.])])
+test "x$enable_filter_test" = xyes || enable_filter_test=no
+AC_MSG_RESULT($enable_filter_test)
+
 AM_CONDITIONAL([USE_NETCDF4], [test "x$nc_build_v4" = xyes])
 AM_CONDITIONAL([BUILD_V2], [test "x$nc_build_v2" = xyes])
 AM_CONDITIONAL([USE_LOGGING], [test "x$nc_has_logging" = xyes])
@@ -539,6 +549,8 @@ AM_CONDITIONAL([BUILD_DAP], [test "x$nc_has_dap" = xyes])
 AM_CONDITIONAL([BUILD_PNETCDF], [test "x$nc_has_pnetcdf" = xyes])
 AM_CONDITIONAL([BUILD_PARALLEL4], [test "x$nc_has_parallel4" = xyes])
 AM_CONDITIONAL([BUILD_PARALLEL], [test "x$nc_has_pnetcdf" = xyes -o "x$nc_has_parallel4" = xyes])
+AM_CONDITIONAL([TEST_FILTERS], [test "x$enable_filter_test" = xyes])
+
 AC_CHECK_HEADER(stdlib.h, ,AC_DEFINE([NO_STDLIB_H], [], [no stdlib.h]))
 AC_CHECK_HEADER(sys/types.h, ,AC_DEFINE([NO_SYS_TYPES_H], [], [no sys_types.h]))
 AC_CHECK_HEADERS([sys/param.h])

--- a/docs/netcdf-f90-sec6-variables.md
+++ b/docs/netcdf-f90-sec6-variables.md
@@ -509,7 +509,181 @@ NF90_INQ_VAR_FILL(INTEGER NCID, INTEGER VARID, INTEGER NO_FILL, FILL_VALUE)
 
 ## Example
 
-6.6 Get Information about a Variable from Its ID: NF90_INQUIRE_VARIABLE {#f90-get-information-about-a-variable-from-its-id-nf90_inquire_variable}
+6.6 Define Filter Parameters for a Variable: `nf90_def_var_filter` {#f90-define-filter-parameters-for-a-variable-nf90_def_var_filter}
+===========
+
+
+
+The function nf90\_def\_var\_filter sets the filter parameters for a
+variable in a netCDF-4 file.
+
+This function must be called after the variable is defined, but before
+nf90\_enddef is called.
+
+
+
+## Usage
+
+
+~~~~.fortran
+
+function nf90_def_var_filter(ncid, varid, filterid, nparams, params);
+   integer, intent(in) :: ncid, varid, filterid, nparams
+   integer, dimension(:), intent(in) :: params
+
+~~~~
+
+
+`ncid`
+
+:   NetCDF ID, from a previous call to nf90\_open or nf90\_create.
+
+`varid`
+
+:   Variable ID.
+
+`filterid`
+
+:   The HDFGroup assigned filter id (e.g. 307 for bzip2).
+
+`nparams`
+
+:   The number of parameters for the filter
+
+`params`
+
+:   A vector of parameters of size nparams.
+
+
+## Return Codes
+
+`NF90_NOERR`
+
+:   No error.
+
+`NF90_BADID`
+
+:   Bad ncid.
+
+`NF90_ENOTNC4`
+
+:   Not a netCDF-4 file.
+
+`NF90_ENOTVAR`
+
+:   Can’t find this variable.
+
+`NF90_ELATEDEF`
+
+:   This variable has already been the subject of a NF90\_ENDDEF call.
+    In netCDF-4 files NF90\_ENDDEF will be called automatically for any
+    data read or write. Once enddef has been called, it is impossible to
+    set the fill for a variable.
+
+`NF90_ENOTINDEFINE`
+
+:   Not in define mode. This is returned for netCDF classic or 64-bit
+    offset files, or for netCDF-4 files, when they were been created
+    with NF90\_STRICT\_NC3 flag. (see section
+    [NF90\_CREATE](#NF90_005fCREATE)).
+
+`NF90_EPERM`
+
+:   Attempt to create object in read-only file.
+
+`NF90_EFILTER`
+
+:   Invalid filter id or parameters
+
+
+## Example
+
+6.7 Get information about any Filter associated with a variable: `nf90_inq_var_filter` {#f90-get-information-about-a-variable-from-its-id-nf90_inq_var_filter}
+===========
+
+
+The function nf90\_inq\_var\_filter gets the filter id and parameters for a
+variable in a netCDF-4 file.
+
+
+## Usage
+
+
+~~~~.fortran
+
+function nf90_inq_var_filter(ncid, varid, filterid, nparams, params);
+   integer, intent(in) :: ncid, varid, filterid, nparams
+   integer, intent(out) :: filterid, nparams
+   integer, dimension(:), intent(out) :: params
+
+~~~~
+
+
+`ncid`
+
+:   NetCDF ID, from a previous call to nf90\_open or nf90\_create.
+
+`varid`
+
+:   Variable ID.
+
+`filterid`
+
+:   Store the the HDFGroup assigned filter id
+
+`nparams`
+
+:   Stor the number of parameters for the filter
+
+`params`
+
+:   Store the vector of parameters of size nparams.
+
+## Return Codes
+
+`NF90_NOERR`
+
+:   No error.
+
+`NF90_BADID`
+
+:   Bad ncid.
+
+`NF90_ENOTNC4`
+
+:   Not a netCDF-4 file.
+
+`NF90_ENOTVAR`
+
+:   Can’t find this variable.
+
+`NF90_ELATEDEF`
+
+:   This variable has already been the subject of a NF90\_ENDDEF call.
+    In netCDF-4 files NF90\_ENDDEF will be called automatically for any
+    data read or write. Once enddef has been called, it is impossible to
+    set the fill for a variable.
+
+`NF90_ENOTINDEFINE`
+
+:   Not in define mode. This is returned for netCDF classic or 64-bit
+    offset files, or for netCDF-4 files, when they were been created
+    with NF90\_STRICT\_NC3 flag. (see section
+    [NF90\_CREATE](#NF90_005fCREATE)).
+
+`NF90_EPERM`
+
+:   Attempt to create object in read-only file.
+
+`NF90_EFILTER`
+
+:   Invalid filter id or parameters
+
+
+## Example
+
+
+6.8 Get Information about a Variable from Its ID: NF90_INQUIRE_VARIABLE {#f90-get-information-about-a-variable-from-its-id-nf90_inquire_variable}
 ===========
 
 NF90\_INQUIRE\_VARIABLE returns information about a netCDF variable
@@ -656,7 +830,7 @@ named rh in an existing netCDF dataset named foo.nc:
 ~~~~
 
 
-6.7 Get the ID of a variable from the name: NF90_INQ_VARID {#f90-get-the-id-of-a-variable-from-the-name-nf90_inq_varid}
+6.9 Get the ID of a variable from the name: NF90_INQ_VARID {#f90-get-the-id-of-a-variable-from-the-name-nf90_inq_varid}
 ===========
 
 
@@ -734,7 +908,7 @@ named rh in an existing netCDF dataset named foo.nc:
 ~~~~
 
 
-6.8 Writing Data Values: NF90_PUT_VAR {#f90-writing-data-values-nf90_put_var}
+6.10 Writing Data Values: NF90_PUT_VAR {#f90-writing-data-values-nf90_put_var}
 ===========
 
 
@@ -1092,7 +1266,7 @@ functions:
 
 
 
-6.9 Reading Data Values: NF90_GET_VAR {#f90-reading-data-values-nf90_get_var}
+6.11 Reading Data Values: NF90_GET_VAR {#f90-reading-data-values-nf90_get_var}
 ===========
 
 
@@ -1457,7 +1631,7 @@ using Fortran 90 intrinsic functions:
 
 
 
-6.10 Reading and Writing Character String Values {#f90-reading-and-writing-character-string-values}
+6.12 Reading and Writing Character String Values {#f90-reading-and-writing-character-string-values}
 ===========
 
 Character strings are not a primitive netCDF external data type under
@@ -1555,7 +1729,7 @@ array variables:
 ~~~~
 
 
-6.11 Fill Values {#f90-fill-values}
+6.13 Fill Values {#f90-fill-values}
 ===========
 
 What happens when you try to read a value that was never written in an
@@ -1599,7 +1773,7 @@ as double) to a smaller type (such as float), if the fill value for the
 larger type cannot be represented in the smaller type.
 
 
-6.12 NF90_RENAME_VAR {#f90-nf90_rename_var}
+6.14 NF90_RENAME_VAR {#f90-nf90_rename_var}
 ===========
 
 
@@ -1682,7 +1856,7 @@ rel\_hum in an existing netCDF dataset named foo.nc:
 ~~~~
 
 
-6.13 Change between Collective and Independent Parallel Access: NF90_VAR_PAR_ACCESS {#f90-change-between-collective-and-independent-parallel-access-nf90_var_par_access}
+6.15 Change between Collective and Independent Parallel Access: NF90_VAR_PAR_ACCESS {#f90-change-between-collective-and-independent-parallel-access-nf90_var_par_access}
 ===========
 
 

--- a/fortran/module_netcdf4_nc_interfaces.f90
+++ b/fortran/module_netcdf4_nc_interfaces.f90
@@ -737,6 +737,20 @@ Interface
 
  End Function nc_inq_var_fill
 End Interface
+!------------------------------- nc_inq_varnparams ------------------------------
+!**** NOT a Netcdf C function. Added to nf_lib.c support Fortran interaces
+Interface
+ Function nc_inq_varnparams(ncid, varid, nparams) BIND(C)
+
+ USE ISO_C_BINDING, ONLY: C_INT, C_SIZE_T
+
+ Integer(C_INT), VALUE         :: ncid, varid
+ Integer(C_SIZE_T), Intent(INOUT) :: nparams
+
+ Integer(C_INT)                 :: nc_inq_nparams
+
+ End Function nc_inq_varnparams
+End Interface
 !------------------------------- nc_inq_var_szip ------------------------------
 Interface
  Function nc_inq_var_szip(ncid, varid, options_mask, pixels_per_block) BIND(C)
@@ -878,6 +892,37 @@ Interface
  Integer(C_INT)                :: nc_inq_var_endian
 
  End Function nc_inq_var_endian
+End Interface
+!------------------------------- nc_def_var_filter ------------------------
+Interface
+ Function nc_def_var_filter(ncid, varid, id, nparams, params) BIND(C)
+
+ USE ISO_C_BINDING, ONLY: C_INT, C_SIZE_T
+
+ Integer(C_INT), VALUE :: ncid, varid, id
+
+ Integer(C_SIZE_T), VALUE :: nparams
+
+ Integer(C_INT) :: params(*)
+
+ Integer(C_INT)        :: nc_def_var_filter
+
+ End Function nc_def_var_filter
+End Interface
+!------------------------------- nc_inq_var_filter ----------------------------------
+Interface
+ Function nc_inq_var_filter(ncid, varid, id, nparams, params) BIND(C)
+
+ USE ISO_C_BINDING, ONLY: C_INT, C_SIZE_T
+
+ Integer(C_INT), VALUE          :: ncid, varid
+ Integer(C_INT), Intent(INOUT)  :: id
+ Integer(C_SIZE_T), Intent(INOUT) :: nparams
+ Integer(C_INT), Intent(INOUT)  :: params(*)
+
+ Integer(C_INT)                :: nc_inq_var_filter
+
+ End Function nc_inq_var_filter
 End Interface
 !------------------------------- nc_put_att -----------------------------------
 Interface

--- a/fortran/module_netcdf4_nf_interfaces.F90
+++ b/fortran/module_netcdf4_nf_interfaces.F90
@@ -624,6 +624,28 @@ Interface
 
  End Function nf_inq_var_endian
 End Interface
+!------------------------------- nf_def_var_filter ------------------------
+Interface
+ Function nf_def_var_filter(ncid, varid, id, nparams, params) RESULT(status)
+
+ Integer, Intent(IN) :: ncid, varid, id, nparams
+ Integer, Intent(IN) :: params(*)
+ Integer                :: status
+
+ End Function nf_def_var_filter
+End Interface
+!------------------------------- nf_inq_var_filter ----------------------------------
+Interface
+ Function nf_inq_var_filter(ncid, varid, id, inparams, params) RESULT(status)
+
+ Integer, Intent(IN)     :: ncid, varid
+ Integer, Intent(INOUT)  :: id
+ Integer, Intent(INOUT)  :: inparams
+ Integer, Intent(INOUT)  :: params(*)
+ Integer                :: status
+
+ End Function nf_inq_var_filter
+End Interface
 !--------------------------------- nf_put_att --------------------------------
 ! Commented out because we use C_CHAR array to pass data of different
 ! type to a C void pointer

--- a/fortran/netcdf4.inc
+++ b/fortran/netcdf4.inc
@@ -237,6 +237,12 @@
       integer nf_inq_var_endian
       external nf_inq_var_endian
 
+      integer nf_def_var_filter
+      external nf_def_var_filter
+
+      integer nf_inq_var_filter
+      external nf_inq_var_filter
+
 !     User defined types.
       integer nf_inq_typeids
       external nf_inq_typeids

--- a/fortran/netcdf4_externals.f90
+++ b/fortran/netcdf4_externals.f90
@@ -27,4 +27,5 @@
        nf_get_vara_int64, nf_get_vars_int64, nf_get_varm_int64, &
        nf_get_var_int64, nf_get_chunk_cache, nf_set_chunk_cache, &
        nf_inq_var_szip, nf_free_vlens, nf_free_string, &
-       nf_set_var_chunk_cache, nf_get_var_chunk_cache, nf_rename_grp
+       nf_set_var_chunk_cache, nf_get_var_chunk_cache, nf_rename_grp, &
+       nf_def_var_filter, nf_inq_var_filter

--- a/fortran/netcdf4_func.f90
+++ b/fortran/netcdf4_func.f90
@@ -578,6 +578,28 @@
     nf90_inq_var_endian = nf_inq_var_endian(ncid, varid, endian)
   end function nf90_inq_var_endian
   ! -----------
+  function nf90_def_var_filter(ncid, varid, filterid, nparams, params)
+    integer, intent(in) :: ncid
+    integer, intent(in) :: varid
+    integer, intent(in) :: filterid
+    integer, intent(in) :: nparams
+    integer, intent(in) :: params(*)
+    integer :: nf90_def_var_filter
+  
+    nf90_def_var_filter = nf_def_var_filter(ncid, varid, filterid, nparams, params)
+  end function nf90_def_var_filter
+  ! -----------
+  function nf90_inq_var_filter(ncid, varid, filterid, nparams, params)
+    integer, intent(in) :: ncid
+    integer, intent(in) :: varid
+    integer, intent(out) :: filterid
+    integer, intent(out) :: nparams
+    integer, dimension(:), intent(out) :: params
+    integer :: nf90_inq_var_filter
+  
+    nf90_inq_var_filter = nf_inq_var_filter(ncid, varid, filterid, nparams, params)
+  end function nf90_inq_var_filter
+  ! -----------
 !  function nf90_def_var_fill(ncid, varid, no_fill, fill)
 !    integer, intent(in) :: ncid
 !    integer, intent(in) :: varid

--- a/fortran/netcdf4_visibility.f90
+++ b/fortran/netcdf4_visibility.f90
@@ -19,6 +19,6 @@ public :: nf90_create_par, nf90_open_par, nf90_var_par_access, &
      nf90_def_var_fill, nf90_inq_var_fill, &
      nf90_def_var_endian, nf90_inq_var_endian, nf90_inq_user_type, &
      nf90_put_att_any, nf90_get_att_any, nf90_get_var_any, nf90_put_var_any, &
-     nf90_rename_grp
+     nf90_rename_grp, nf90_def_var_filter, nf90_inq_var_filter
      
   

--- a/fortran/nf_lib.c
+++ b/fortran/nf_lib.c
@@ -186,6 +186,18 @@ nc_inq_numtypes(int ncid, int *numtypes)
     return ret;
 }  
  
+extern int
+nc_inq_varnparams(int ncid, int varid, size_t* nparamsp)
+{
+ int ret;
+ unsigned int id;
+ size_t nparams;
+
+ if ((ret = nc_inq_var_filter(ncid, varid, &id, &nparams, NULL))) 
+    return ret;
+ if(nparamsp) *nparamsp = nparams;
+}  
+ 
 #endif /*USE_NETCDF4*/
 
 /*

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -1800,6 +1800,77 @@
  status  = cstatus
 
  End Function nf_inq_var_endian
+!-------------------------------- nf_def_var_filter ---------------------------
+ Function nf_def_var_filter( ncid, varid, filterid, nparams, params) RESULT(status)
+
+! define variable filter 
+
+ USE netcdf4_nc_interfaces
+
+ Implicit NONE
+
+ Integer, Intent(IN) :: ncid, varid, filterid, nparams
+ Integer, Intent(IN) :: params(*)
+
+ Integer             :: status
+
+ Integer(C_INT) :: cncid, cvarid, cfilterid, cstatus
+ Integer(C_SIZE_T) :: cnparams
+
+ cncid    = ncid
+ cvarid   = varid-1
+ cfilterid = filterid
+ cnparams = nparams
+
+ cstatus = nc_def_var_filter(cncid, cvarid, cfilterid, cnparams, params)
+
+ status = cstatus
+
+ End Function nf_def_var_filter
+!-------------------------------- nf_inq_var_filter -----------------------------
+ Function nf_inq_var_filter(ncid, varid, filterid, nparams, params) RESULT(status)
+
+! get filter variables
+ 
+ USE netcdf4_nc_interfaces
+
+ Implicit NONE
+
+ Integer, Intent(IN)  :: ncid, varid
+ Integer, Intent(OUT) :: filterid, nparams
+ Integer, Intent(OUT) :: params(*)
+
+ Integer                :: status
+
+ Integer(C_INT) :: cncid, cvarid, cstatus, cstatus1, cfilterid
+ Integer(C_SIZE_T) :: cnparams
+ Integer(C_INT), ALLOCATABLE :: cparams(:)
+
+ cncid  = ncid
+ cvarid = varid-1
+ params(1) = 0
+
+ cstatus1 = nc_inq_varnparams(cncid, cvarid, cnparams)
+
+ If (cstatus1 == NC_NOERR) Then
+   ALLOCATE(cparams(cnparams))
+ Else
+   ALLOCATE(cparams(1))
+ EndIf
+
+ cstatus = nc_inq_var_filter(cncid, cvarid, cfilterid, cnparams, cparams)
+
+ If (cstatus == NC_NOERR) Then
+   filterid = cfilterid
+   nparams = cnparams
+   If (cnparams > 0) Then
+     params(1:nparams) = cparams(1:nparams)
+   EndIf
+ EndIf
+
+ status = cstatus
+
+ End Function nf_inq_var_filter
 !--------------------------------- nf_put_att --------------------------------
  Function nf_put_att(ncid, varid, name, xtype, nlen, value) RESULT(status)
 

--- a/nf03_test/CMakeLists.txt
+++ b/nf03_test/CMakeLists.txt
@@ -52,7 +52,9 @@ IF(USE_NETCDF4)
     LIST(APPEND check_PROGRAMS f03tst_parallel)
     LIST(APPEND CLEANFILES ftst_parallel.nc)
     SET(f03tst_parallel_SOURCES f03tst_parallel.F)
-  ENDIF(TEST_PARALLEL)
+ENDIF(TEST_PARALLEL)
+
+
 ENDIF(USE_NETCDF4)
 
 # This is the fortran v2 test. It depends on the utilities being built

--- a/nf03_test/Makefile.am
+++ b/nf03_test/Makefile.am
@@ -28,6 +28,8 @@ AM_FCFLAGS += -I$(top_srcdir)/nf_test
 
 AM_FFLAGS = ${AM_FCFLAGS}
 
+AM_TESTS_ENVIRONMENT = HDF5_PLUGIN_PATH='@PLUGINDIR@' ; export HDF5_PLUGIN_PATH ;
+
 TESTS =
 
 # All tests need to link to fortran and C libraries.
@@ -73,9 +75,10 @@ f03tst_groups_SOURCES = module_tests.F90 f03tst_groups.F f03lib_f_interfaces.f90
 TESTS += f03tst_vars f03tst_vars2 f03tst_vars3 f03tst_vars4 f03tst_vars5 \
          f03tst_vars6 f03tst_types f03tst_types2 f03tst_types3 f03tst_groups \
          f03tst_open_mem
+
 CLEANFILES += ftst_vars.nc ftst_vars2.nc ftst_vars3.nc ftst_vars4.nc	\
               ftst_vars5.nc ftst_vars6.nc ftst_types.nc ftst_types2.nc \
-              ftst_types3.nc ftst_groups.nc f03tst_open_mem.nc
+              ftst_types3.nc ftst_groups.nc f03tst_open_mem.nc ftst_filter.nc
 
 # This is a netCDF-4 V2 test program.
 if BUILD_V2

--- a/nf_test/CMakeLists.txt
+++ b/nf_test/CMakeLists.txt
@@ -134,6 +134,12 @@ if (USE_NETCDF4)
 
   ENDIF (TEST_PARALLEL)
 
+  IF(ENABLE_FILTER_TEST)
+    LIST(APPEND check_PROGRAMS ftst_filter)
+    LIST(APPEND CLEANFILES ftst_filter.nc)
+    SET(ftst_filter_SOURCES ftst_filter.F)
+  ENDIF(ENABLE_FILTER_TEST)
+
 endif(USE_NETCDF4)
 
 # This is the fortran v2 test. It depends on the utilities being built

--- a/nf_test/Makefile.am
+++ b/nf_test/Makefile.am
@@ -145,6 +145,14 @@ ftst_parallel_SOURCES = ftst_parallel.F
 ftst_parallel_nasa_SOURCES = ftst_parallel_nasa.F
 endif # TEST_PARALLEL
 
+# Test filters
+if TEST_FILTERS
+check_PROGRAMS += ftst_filter 
+ftst_filter_SOURCES = ftst_filter.F f03lib_f_interfaces.f90 f03lib.c handle_err.F
+TESTS += ftst_filter
+endif
+
+
 endif #USE_NETCDF4
 
 # This is the fortran v2 test. It depends on the utilities being built

--- a/nf_test/ftst_filter.F
+++ b/nf_test/ftst_filter.F
@@ -1,0 +1,124 @@
+C********************************************************************
+C   Copyright 1993, UCAR/Unidata
+C   See netcdf/COPYRIGHT file for copying and redistribution conditions.
+C   $Id: ftest.F,v 1.11 2009/01/25 14:33:45 ed Exp $
+C********************************************************************
+
+C     This is part of the netCDF package.
+C     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
+C     See COPYRIGHT file for conditions of use.
+
+C     This program tests netCDF-4 variable Filter support from fortran.
+
+      program ftst_filter
+      implicit none
+      include 'netcdf.inc'
+
+C     This is the name of the data file we will create.
+      character*(*) FILE_NAME
+      parameter (FILE_NAME='ftst_filter.nc')
+
+C     We are writing 2D data, a 6 x 12 grid. 
+      integer NDIMS
+      parameter (NDIMS=2)
+      integer NX, NY
+      parameter (NX = 6, NY = 12)
+      integer DATAOFFSET
+C      parameter (DATAOFFSET = 2147483646)
+      parameter (DATAOFFSET = 0)
+
+C     NetCDF IDs.
+      integer ncid, varid, dimids(NDIMS)
+      integer x_dimid, y_dimid
+
+C     This is the data array we will write, and a place to store it when
+C     we read it back in.
+      integer data_out(NY, NX), data_in(NY, NX)
+
+C     For checking our data file to make sure it's correct.
+      integer chunks(NDIMS), chunks_in(NDIMS)
+      integer filterid, nparams, params(1)
+
+C     Loop indexes, and error handling.
+      integer x, y, retval
+
+C     Create some pretend data.
+      do x = 1, NX
+         do y = 1, NY
+            data_out(y, x) = DATAOFFSET + x * y
+         end do
+      end do
+
+      print *, ''
+      print *,'*** Testing definition netCDF-4 Filters'
+
+C     Create the netCDF file.
+      retval = nf_create(FILE_NAME, NF_CLOBBER+NF_NETCDF4, ncid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Define the dimensions.
+      retval = nf_def_dim(ncid, "x", NX, x_dimid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+      retval = nf_def_dim(ncid, "y", NY, y_dimid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Define the variable. 
+      dimids(1) = y_dimid
+      dimids(2) = x_dimid
+      retval = nf_def_var(ncid, "data", NF_INT64, NDIMS, dimids, varid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Turn on chunking.
+      chunks(1) = NY
+      chunks(2) = NX
+      retval = nf_def_var_chunking(ncid, varid, 0, chunks)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Set bzip filter on variable
+      params(1) = 9
+      retval = nf_def_var_filter(ncid, varid, 307, 1, params)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+      retval = nf_enddef(ncid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Write the pretend data to the file.
+      retval = nf_put_var_int(ncid, varid, data_out)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Close the file. 
+      retval = nf_close(ncid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Reopen the file and check again.
+      retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+C     Find our variable.
+      retval = nf_inq_varid(ncid, "data", varid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+      if (varid .ne. 1) stop 2
+
+C     Check the filter
+      params(1) = -1
+      retval = nf_inq_var_filter(ncid, varid, filterid, nparams, params)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+      if (filterid .ne. 307) stop 2
+      if (nparams .ne. 1) stop 2
+      if (params(1) .ne. 9) stop 2
+
+C     Read the data and check it.
+      retval = nf_get_var_int(ncid, varid, data_in)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+      do x = 1, NX
+         do y = 1, NY
+            if (data_in(y, x) .ne. data_out(y, x)) stop 2
+         end do
+      end do
+
+C     Close the file. 
+      retval = nf_close(ncid)
+      if (retval .ne. nf_noerr) call handle_err(retval)
+
+      print *,'*** SUCCESS!'
+      end

--- a/nf_test/ftst_rengrps.F
+++ b/nf_test/ftst_rengrps.F
@@ -9,9 +9,9 @@ C     $Id: ftst_rengrps.F,v 1.3 2010/02/03 14:35:21 ed Exp $
       program ftst_rengrps
 C      use typeSizes
 C      use netcdf
-      use netcdf4_f03
+C      use netcdf4_f03
       implicit none
-C     include "netcdf.inc"
+     include "netcdf.inc"
       
 C This is the name of the data file we will create.
       character (len = *), parameter :: FILE_NAME = "ftst_rengrps.nc"


### PR DESCRIPTION
re: Issue https://github.com/Unidata/netcdf-fortran/issues/104

Added nf_def_var_filter and nf_inq_var_filter to the fortran API.
Also added a testcase: f03tst_filter.F.

Not clear if this will work with F77.

May need some tweeking depending on the compiler used; I was
using gfortran version 7.