### PR TITLE
Detect inability to link to netcdf-c library at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -384,7 +384,7 @@ AC_SEARCH_LIBS([H5DSis_scale], [hdf5_hldll hdf5_hl], [], [])
 
 # Find the netCDF header and library.
 AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([netcdf.h could not be found. Please set CPPFLAGS.])])
-AC_SEARCH_LIBS([nc_open], [netcdf])
+AC_SEARCH_LIBS([nc_open], [netcdf], [], [AC_MSG_ERROR([Could not link to netcdf C library. Please set LDFLAGS.])])
 
 # See if various functions are available
 AC_CHECK_FUNCS([nc_def_opaque nccreate nc_set_log_level oc_open])

--- a/nf_test/Makefile.am
+++ b/nf_test/Makefile.am
@@ -24,8 +24,9 @@ LDADD = ${top_builddir}/fortran/libnetcdff.la
 check_PROGRAMS = nf_test
 TESTS = nf_test
 
-nf_test_SOURCES = f03lib_f_interfaces.f90 test_get.m4 test_put.m4 nf_error.F nf_test.F	\
-                  test_read.F test_write.F util.F f03lib.c tests.inc
+nf_test_SOURCES = f03lib_f_interfaces.f90 test_get.m4 test_put.m4	\
+nf_error.F nf_test.F test_read.F test_write.F util.F f03lib.c		\
+tests.inc
 
 # The create_fills shell creates the file fills.nc, needed by later
 # tests.
@@ -63,12 +64,12 @@ ftst_rengrps_SOURCES = ftst_rengrps.F f03lib_f_interfaces.f90 f03lib.c handle_er
 
 # Add these netCDF-4 f90 test programs.
 check_PROGRAMS += f90tst_vars tst_types tst_types2 f90tst_vars_vlen	\
-                  tst_f90_nc4 f90tst_grps f90tst_fill f90tst_fill2 f90tst_vars3		\
-                  f90tst_vars4 f90tst_vars2 f90tst_path f90tst_rengrps
+tst_f90_nc4 f90tst_grps f90tst_fill f90tst_fill2 f90tst_vars3		\
+f90tst_vars4 f90tst_vars2 f90tst_path f90tst_rengrps
 
-TESTS += f90tst_vars tst_types tst_types2 f90tst_vars_vlen tst_f90_nc4	\
-         f90tst_grps f90tst_fill f90tst_fill2 f90tst_vars3 f90tst_vars4		\
-         f90tst_vars2 f90tst_path f90tst_rengrps
+TESTS += f90tst_vars tst_types tst_types2 f90tst_vars_vlen	\
+tst_f90_nc4 f90tst_grps f90tst_fill f90tst_fill2 f90tst_vars3	\
+f90tst_vars4 f90tst_vars2 f90tst_path f90tst_rengrps
 
 f90tst_vars_SOURCES = f90tst_vars.f90
 tst_types_SOURCES = tst_types.f90
@@ -108,7 +109,7 @@ endif #BUILD_BENCHMARKS
 # Test parallel I/O.
 if TEST_PARALLEL
 check_PROGRAMS += f90tst_parallel f90tst_parallel2 f90tst_parallel3	\
-                  f90tst_nc4_par
+f90tst_nc4_par
 #f90tst_parallel_fill
 TESTS += run_f90_par_test.sh
 


### PR DESCRIPTION
Fixes #123.

We have been getting some reports of netcdf-fortran build problems with static libraries.

Everyone is using static because pnetcdf now build static-only by default, so anyone including pnetcdf runs into the problem that they cannot build shared libraries if pnetcdf is static-only. The best answer is to rebuild pnetcdf with --enable-shared, but instead, people build netcdf-c and netcdf-fortran with --disable-shared.

Static only builds work fine in netcdf-fortran, but when not all necessary library locations are specified in LDFLAGS, the build fails in a confusing way. Instead of detecting the problem during the configure step, it is ignored by configure and the user sees the problem as a linking error.

The answer is to fail out in configure if the netcdf-c library cannot be linked due to missing arguments in LDFLAGS. This allows the user to sort out their flags and try again.

This PR accomplishes that change.

