### PR TITLE
bugfix in nf-config.in

### DIFF
--- a/nf-config.in
+++ b/nf-config.in
@@ -4,9 +4,9 @@
 # various things about the netCDF fortran installation.
 
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
 
 cc="@CC@"
 fc="@FC@"


### PR DESCRIPTION
If user specific installation paths are specified for executables, libraries and include files, they are ignored and reset based on `$prefix`.