### PR TITLE
fix cache preemption issue, also some warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -507,7 +507,6 @@ AC_SUBST(HAS_NC4,[$nc_build_v4])
 # about where files live.  AC_CONFIG_LINKS provides a mechanism to
 # link/copy files if an out-of-source build is happening.
 AC_CONFIG_LINKS([nf_test/fills.nc:nf_test/ref_fills.nc])
-#AC_CONFIG_LINKS([nf_test/ref_fills.nc:nf03_test/ref_fills.nc])
 
 AC_MSG_NOTICE([generating header files and makefiles])
 

--- a/examples/F90/simple_xy_par_rd.f90
+++ b/examples/F90/simple_xy_par_rd.f90
@@ -40,7 +40,7 @@ program simple_xy_par_rd
   integer :: p, my_rank, ierr
 
   ! Loop indexes, and error handling.
-  integer :: x, y, stat
+  integer :: x, stat
 
   ! Initialize MPI, learn local rank and total number of processors.
   call MPI_Init(ierr)

--- a/fortran/netcdf4_eightbyte.f90
+++ b/fortran/netcdf4_eightbyte.f90
@@ -775,7 +775,7 @@ function nf90_put_var_EightByteInt(ncid, varid, values, start)
   integer                                      :: nf90_put_var_EightByteInt
 
   integer, dimension(nf90_max_var_dims) :: localIndex
-  integer                               :: counter, format_num
+  integer                               :: format_num
 
   ! Set local arguments to default values
   localIndex(:) = 1
@@ -800,7 +800,7 @@ function nf90_get_var_EightByteInt(ncid, varid, values, start)
   integer                                      :: nf90_get_var_EightByteInt
 
   integer, dimension(nf90_max_var_dims) :: localIndex
-  integer                               :: counter, format_num
+  integer                               :: format_num
   integer                               :: defaultInteger
   integer (kind = EightByteInt)         :: defaultInteger8
 

--- a/fortran/netcdf4_file.f90
+++ b/fortran/netcdf4_file.f90
@@ -3,7 +3,7 @@
 
 ! This file contains the netcdf-4 file open and create functions.
 
-! $Id: netcdf4_constants.f90,v 1.14 2010/05/25 13:53:00 ed Exp $
+! @author Ed Hartnett
 ! -------
 function nf90_open(path, mode, ncid, chunksize, cache_size, cache_nelems, &
      cache_preemption, comm, info)

--- a/fortran/netcdf4_file.f90
+++ b/fortran/netcdf4_file.f90
@@ -86,10 +86,9 @@ function nf90_create(path, cmode, ncid, initialsize, chunksize, cache_size, &
   integer, optional, intent(in) :: cache_preemption
   integer, optional, intent(in) :: comm, info
   integer :: size_in, nelems_in, preemption_in
-  integer :: size_out, nelems_out, preemption_out, ret
+  integer :: size_out, nelems_out, preemption_out
   integer :: nf90_create
   integer :: fileSize, chunk
-  integer :: x
 
   ! Just ignore options netCDF-3 options for netCDF-4 files, or
   ! netCDF-4 options, for netCDF-3 files, so that the same user code

--- a/fortran/netcdf4_file.f90
+++ b/fortran/netcdf4_file.f90
@@ -46,7 +46,7 @@ function nf90_open(path, mode, ncid, chunksize, cache_size, cache_nelems, &
         nelems_out = nelems_in
      end if
      if (present(cache_preemption)) then
-        preemption_out = cache_preemption
+        preemption_out = int(cache_preemption * 100)
      else
         preemption_out = preemption_in
      end if

--- a/fortran/netcdf4_func.f90
+++ b/fortran/netcdf4_func.f90
@@ -36,7 +36,7 @@
           nelems_out = nelems_in
        end if
        if (present(cache_preemption)) then
-          preemption_out = cache_preemption
+          preemption_out = int(cache_preemption * 100)
        else
           preemption_out = preemption_in
        end if
@@ -59,7 +59,7 @@
     integer :: size_in, nelems_in, preemption_in
     integer :: size_out, nelems_out, preemption_out, ret
     integer :: nf90_open_par
-  
+
     ! If the user specified chuck cache parameters, use them. But user
     ! may have specified one, two, or three settings. Leave the others
     ! unchanged.
@@ -81,7 +81,7 @@
           nelems_out = nelems_in
        end if
        if (present(cache_preemption)) then
-          preemption_out = cache_preemption
+          preemption_out = int(cache_preemption * 100)
        else
           preemption_out = preemption_in
        end if

--- a/fortran/netcdf4_func.f90
+++ b/fortran/netcdf4_func.f90
@@ -786,10 +786,8 @@
      integer, dimension(:), optional, intent( in) :: start, count, stride, map
      integer                                      :: nf90_get_var_any
  
-     integer, dimension(nf90_max_var_dims) :: textDimIDs
-     integer, dimension(nf90_max_var_dims) :: localStart, localCount, localStride 
-     integer                               :: stringLength
- 
+     integer, dimension(nf90_max_var_dims) :: localStart, localCount, localStride
+
      ! Set local arguments to default values
      localStart (:)  = 1
      localCount (1)  = len(values); localCount (2:) = 1

--- a/fortran/netcdf_expanded.f90
+++ b/fortran/netcdf_expanded.f90
@@ -6,8 +6,7 @@
      integer                                      :: nf90_put_var_OneByteInt
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -23,8 +22,7 @@
      integer                                      :: nf90_put_var_TwoByteInt
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -40,8 +38,7 @@
      integer                                      :: nf90_put_var_FourByteInt
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -57,8 +54,7 @@
      integer                                      :: nf90_put_var_FourByteReal
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -74,8 +70,7 @@
      integer                                      :: nf90_put_var_EightByteReal
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -91,8 +86,7 @@
      integer                                      :: nf90_get_var_OneByteInt
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -108,8 +102,7 @@
      integer                                      :: nf90_get_var_TwoByteInt
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -125,7 +118,6 @@
      integer                                      :: nf90_get_var_FourByteInt
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
      integer                               :: defaultInteger
      
      ! Set local arguments to default values
@@ -144,8 +136,7 @@
      integer                                      :: nf90_get_var_FourByteReal
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)
@@ -161,8 +152,7 @@
      integer                                      :: nf90_get_var_EightByteReal
  
      integer, dimension(nf90_max_var_dims) :: localIndex
-     integer                               :: counter
- 
+
      ! Set local arguments to default values
      localIndex(:) = 1
      if(present(start)) localIndex(:size(start)) = start(:)

--- a/fortran/netcdf_text_variables.f90
+++ b/fortran/netcdf_text_variables.f90
@@ -26,7 +26,7 @@
  
      integer, dimension(nf90_max_var_dims) :: localIndex, textDimIDs
      integer, dimension(nf90_max_var_dims) :: localStart, localCount, localStride 
-     integer                               :: counter, stringLength
+     integer                               :: stringLength
  
      ! Set local arguments to default values
      localStart (:)  = 1
@@ -274,8 +274,7 @@
  
      integer, parameter                  :: numDims = 1
      integer, dimension(nf90_max_var_dims) :: localStart, localCount, localStride, localMap
-     integer                             :: counter
- 
+
      ! Set local arguments to default values
      localStart (:         ) = 1
      localCount (:numDims+1) = (/ len(values(1)), shape(values) /)

--- a/fortran/netcdf_text_variables.f90
+++ b/fortran/netcdf_text_variables.f90
@@ -24,10 +24,8 @@
      integer, dimension(:), optional, intent( in) :: start, count, stride, map
      integer                                      :: nf90_get_var_text
  
-     integer, dimension(nf90_max_var_dims) :: localIndex, textDimIDs
-     integer, dimension(nf90_max_var_dims) :: localStart, localCount, localStride 
-     integer                               :: stringLength
- 
+     integer, dimension(nf90_max_var_dims) :: localStart, localCount, localStride
+
      ! Set local arguments to default values
      localStart (:)  = 1
      localCount (1)  = len(values); localCount (2:) = 1

--- a/fortran/nf_control.F90
+++ b/fortran/nf_control.F90
@@ -213,7 +213,7 @@
  Integer(C_INT)               :: cmode, cncid, cstatus
  Integer(C_SIZE_T)            :: cchunk
  Character(LEN=(LEN(path)+1)) :: cpath
- Integer                      :: inull, ie
+ Integer                      :: ie
 
  cmode  = mode
  cchunk = chunksizehintp
@@ -342,7 +342,7 @@
  cstatus = nc_inq_path(cncid, cpathlen, tmppath)
 
  If (cstatus == NC_NOERR) Then
-    pathlen = cpathlen
+    pathlen = int(cpathlen)
     If (pathlen > LEN(path)) pathlen = LEN(path)
     path = stripCNullchar(tmppath, pathlen)
  EndIf

--- a/fortran/nf_dim.f90
+++ b/fortran/nf_dim.f90
@@ -104,7 +104,7 @@
  If (cstatus == NC_NOERR) Then
     ! Strip C null char from tmpname if present and set end of string
     name = stripCNullChar(tmpname, nlen)
-    dlen   = cdlen
+    dlen   = int(cdlen)
  Endif
 
  status = cstatus
@@ -173,7 +173,7 @@
  cstatus = nc_inq_dimlen(cncid, cdimid, cdlen)
 
  If (cstatus == NC_NOERR) Then
-    dlen   = cdlen
+    dlen   = int(cdlen)
  Endif
  status = cstatus
 

--- a/fortran/nf_genatt.f90
+++ b/fortran/nf_genatt.f90
@@ -60,7 +60,7 @@
 
  If (cstatus == NC_NOERR) Then
     xtype = cxtype
-    nlen  = cnlen
+    nlen  = int(cnlen)
  EndIf
  status = cstatus
 
@@ -130,7 +130,7 @@
  cstatus = nc_inq_attlen(cncid, cvarid, cname(1:ie), cnlen)
 
  If (cstatus == NC_NOERR) Then
-    nlen = cnlen
+    nlen = int(cnlen)
  EndIf
  status = cstatus
 
@@ -257,7 +257,7 @@
  Integer(C_INT)                  :: cncid, cvarid, cstatus
  Character(LEN=(LEN(name)+1))    :: cname 
  Character(LEN=(LEN(newname)+1)) :: cnewname 
- Integer                         :: ie1, ie2, inull
+ Integer                         :: ie1, ie2
 
  cncid  = ncid
  cvarid = varid - 1 ! Subtract 1 to get C varid

--- a/fortran/nf_misc.f90
+++ b/fortran/nf_misc.f90
@@ -6,10 +6,10 @@
 !             Center for Advanced Vehicular Systems
 !             Mississippi State University
 !             rweed@cavs.msstate.edu
- 
+
 
 ! License (and other Lawyer Language)
- 
+
 ! This software is released under the Apache 2.0 Open Source License. The
 ! full text of the License can be viewed at :
 !
@@ -26,109 +26,109 @@
 ! Version 3.: April 2009 - Updated for netCDF 4.0.1
 ! Version 4.: April 2010 - Updated for netCDF 4.1.1
 ! Version 5.: Jan   2016 - General code cleanup
- 
+
 !-------------------------------- nf_inq_libvers ---------------------------
- Function nf_inq_libvers() RESULT(vermsg)
+Function nf_inq_libvers() RESULT(vermsg)
 
-! Return string with current version of NetCDF library
+  ! Return string with current version of NetCDF library
 
- USE netcdf_nc_interfaces
+  USE netcdf_nc_interfaces
 
- Implicit NONE
+  Implicit NONE
 
- Character(LEN=80) :: vermsg
+  Character(LEN=80) :: vermsg
 
- Character(LEN=81), Pointer :: fstrptr
- TYPE(C_PTR)                :: cstrptr
- Integer                    :: inull, ilen
+  Character(LEN=81), Pointer :: fstrptr
+  TYPE(C_PTR)                :: cstrptr
+  Integer                    :: inull, ilen
 
- vermsg = REPEAT(" ", LEN(vermsg)) !initialize vermsg to blanks
+  vermsg = REPEAT(" ", LEN(vermsg)) !initialize vermsg to blanks
 
-! Get C character pointer returned by nc_inq_vers and associate it
-! Fortran character pointer (fstrptr). Have to do this when the C
-! routine allocates space for the pointer and/or knows where it lives
-! not Fortran. This is also how you can pass character data back to
-! FORTRAN from C using a C function that returns a character pointer
-! instead using a void jacket function and passing the string as a hidden 
-! argument. At least this is how cfortran.h appears to do it. 
+  ! Get C character pointer returned by nc_inq_vers and associate it
+  ! Fortran character pointer (fstrptr). Have to do this when the C
+  ! routine allocates space for the pointer and/or knows where it lives
+  ! not Fortran. This is also how you can pass character data back to
+  ! FORTRAN from C using a C function that returns a character pointer
+  ! instead using a void jacket function and passing the string as a hidden
+  ! argument. At least this is how cfortran.h appears to do it.
 
- 
- NULLIFY(fstrptr) ! Nullify fstrptr
 
- cstrptr = nc_inq_libvers()         ! Get C pointer to version string and
+  NULLIFY(fstrptr) ! Nullify fstrptr
 
- Call C_F_POINTER(cstrptr, fstrptr) ! associate it with FORTRAN pointer
+  cstrptr = nc_inq_libvers()         ! Get C pointer to version string and
 
-! Locate first C null character and then set it and remaining characters
-! in string to blanks
+  Call C_F_POINTER(cstrptr, fstrptr) ! associate it with FORTRAN pointer
 
- ilen  = LEN_TRIM(fstrptr)
- inull = SCAN(fstrptr,C_NULL_CHAR)
- If (inull /= 0) ilen = inull-1
- ilen = MAX(1, MIN(ilen,80)) ! Limit ilen to >=1 and <=80
+  ! Locate first C null character and then set it and remaining characters
+  ! in string to blanks
 
-! Load return value with trimmed fstrptr string
+  ilen  = LEN_TRIM(fstrptr)
+  inull = SCAN(fstrptr,C_NULL_CHAR)
+  If (inull /= 0) ilen = inull-1
+  ilen = MAX(1, MIN(ilen,80)) ! Limit ilen to >=1 and <=80
 
- vermsg(1:ilen) = fstrptr(1:ilen)
+  ! Load return value with trimmed fstrptr string
 
- End Function nf_inq_libvers
+  vermsg(1:ilen) = fstrptr(1:ilen)
+
+End Function nf_inq_libvers
 !-------------------------------- nf_stderror ------------------------------
- Function nf_strerror(ncerr) RESULT(errmsg)
+Function nf_strerror(ncerr) RESULT(errmsg)
 
-! Returns an error message string given static error code ncerr
+  ! Returns an error message string given static error code ncerr
 
- USE netcdf_nc_interfaces
+  USE netcdf_nc_interfaces
 
- Implicit NONE
+  Implicit NONE
 
- Integer(KIND=C_INT), Intent(IN) :: ncerr
+  Integer(KIND=C_INT), Intent(IN) :: ncerr
 
- Character(LEN=80)               :: errmsg
+  Character(LEN=80)               :: errmsg
 
- Character(LEN=81), Pointer :: fstrptr
- TYPE(C_PTR)                :: cstrptr
- Integer                    :: inull, ilen
- Integer(KIND=C_INT)        :: cncerr
+  Character(LEN=81), Pointer :: fstrptr
+  TYPE(C_PTR)                :: cstrptr
+  Integer                    :: inull, ilen
+  Integer(KIND=C_INT)        :: cncerr
 
- errmsg = REPEAT(" ", LEN(errmsg)) !initialize errmsg to blanks
+  errmsg = REPEAT(" ", LEN(errmsg)) !initialize errmsg to blanks
 
-! Get C character pointer returned by nc_stderror and associate it
-! Fortran character pointer (fstrptr). Have to do this when the C
-! routine allocates space for the pointer and/or knows where it lives
-! not Fortran. This is also how you can pass character data back to
-! FORTRAN from C using a C function that returns a character pointer
-! instead using a void jacket function and passing the string as a hidden 
-! argument. At least this is how cfortran.h appears to do it. 
- 
- NULLIFY(fstrptr) ! Nullify fstrptr
+  ! Get C character pointer returned by nc_stderror and associate it
+  ! Fortran character pointer (fstrptr). Have to do this when the C
+  ! routine allocates space for the pointer and/or knows where it lives
+  ! not Fortran. This is also how you can pass character data back to
+  ! FORTRAN from C using a C function that returns a character pointer
+  ! instead using a void jacket function and passing the string as a hidden
+  ! argument. At least this is how cfortran.h appears to do it.
 
- cncerr  = ncerr
+  NULLIFY(fstrptr) ! Nullify fstrptr
 
- cstrptr = nc_strerror(cncerr)      ! Return C character pointer and
- Call C_F_POINTER(cstrptr, fstrptr) ! associate C ptr with FORTRAN pointer
+  cncerr  = ncerr
 
-! Locate first C null character and then set it and remaining characters
-! in string to blanks 
+  cstrptr = nc_strerror(cncerr)      ! Return C character pointer and
+  Call C_F_POINTER(cstrptr, fstrptr) ! associate C ptr with FORTRAN pointer
 
- ilen  = LEN_TRIM(fstrptr)
- inull = SCAN(fstrptr,C_NULL_CHAR)
- If (inull /= 0) ilen = inull-1 
- ilen  = MAX(1, MIN(ilen,80)) ! Limit ilen to >=1 and <=80
+  ! Locate first C null character and then set it and remaining characters
+  ! in string to blanks
 
-! Load return value with trimmed fstrptr string
+  ilen  = LEN_TRIM(fstrptr)
+  inull = SCAN(fstrptr,C_NULL_CHAR)
+  If (inull /= 0) ilen = inull-1
+  ilen  = MAX(1, MIN(ilen,80)) ! Limit ilen to >=1 and <=80
 
- errmsg(1:ilen) = fstrptr(1:ilen)
+  ! Load return value with trimmed fstrptr string
 
- End Function nf_strerror
+  errmsg(1:ilen) = fstrptr(1:ilen)
+
+End Function nf_strerror
 !-------------------------------- nf_issyserr ------------------------------
- Function nf_issyserr(nerr) RESULT(status)
+Function nf_issyserr(nerr) RESULT(status)
 
-! Check to see if nerr is > 0
+  ! Check to see if nerr is > 0
 
- Integer, Intent(IN) :: nerr
+  Integer, Intent(IN) :: nerr
 
- Logical             :: status
+  Logical             :: status
 
- status = (nerr > 0) 
+  status = (nerr > 0)
 
- End Function nf_issyserr
+End Function nf_issyserr

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -293,7 +293,7 @@
 
  If (cstatus == NC_NOERR) Then
     ! Return name length 
-     nlen = clen
+     nlen = int(clen)
  EndIf
  status = cstatus
 
@@ -708,7 +708,7 @@
  cstatus = nc_inq_type(cncid, cxtype, cname(1:ie), csize)
 
  If (cstatus == NC_NOERR) Then
-    isize  = csize
+    isize  = int(csize)
  EndIf
  status = cstatus
 
@@ -743,8 +743,8 @@
 
  If (cstatus == NC_NOERR) Then
     name       = stripCNullChar(cname, nlen)
-    isize      = csize
-    nfields    = cnfieldsp
+    isize      = int(csize)
+    nfields    = int(cnfieldsp)
  EndIf
  status  = cstatus
 
@@ -804,7 +804,7 @@
  cstatus = nc_inq_compound_size(cncid, cxtype, csize)
 
  If (cstatus == NC_NOERR) Then
-    isize  = csize
+    isize  = int(csize)
  EndIf
 
  status = cstatus
@@ -833,7 +833,7 @@
  cstatus = nc_inq_compound_nfields(cncid, cxtype, cnfields)
 
  If (cstatus == NC_NOERR) Then
-    nfields = cnfields
+    nfields = int(cnfields)
  EndIf
 
  status  = cstatus
@@ -886,7 +886,7 @@
                                    cfield_typeid, cndims, cdim_sizes)
  If (cstatus == NC_NOERR) Then
    name               = stripCNullChar(cname, nlen)
-   offset             = coffset
+   offset             = int(coffset)
    field_typeid       = cfield_typeid
    ndims              = cndims
    If (ndims > 0) Then
@@ -991,7 +991,7 @@
  cstatus = nc_inq_compound_fieldoffset(cncid, cxtype, cfieldid, coffset)
 
  If (cstatus == NC_NOERR) Then
-    offset = coffset
+    offset = int(coffset)
  EndIf
 
  status = cstatus
@@ -1146,7 +1146,7 @@
 
  If (cstatus == NC_NOERR) Then
     name       = stripCNullChar(cname, nlen)
-    datum_size = cdatum_size 
+    datum_size = int(cdatum_size)
     base_type  = cbase_type 
  EndIf
 
@@ -1187,8 +1187,8 @@
 
  If (cstatus == NC_NOERR) Then
     name       = stripCNullChar(cname, nlen)
-    isize      = csize
-    nfields    = cnfields
+    isize      = int(csize)
+    nfields    = int(cnfields)
     iclass     = cclass
     base_type  = cbase_type
  EndIf
@@ -1298,7 +1298,7 @@
  If (cstatus == NC_NOERR) Then
     name         = stripCNullChar(cname, nlen)
     base_nf_type = c_base_nf_type
-    base_size    = c_base_size
+    base_size    = int(c_base_size)
     num_members  = c_num_members
  EndIf
 

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -264,7 +264,7 @@
  cstatus = nc_inq_grpname_full(cncid, clen, cname)
 
  If (cstatus == NC_NOERR) Then
-    nlen = clen  
+    nlen = int(clen)
     name = stripCNullChar(cname, nl)
  EndIf
  status = cstatus
@@ -433,7 +433,8 @@
 
  cncid     = ncid
  dimids(1) = 0
- 
+ cparent = parent
+
  cstatus = nc_inq_dimids_f(cncid, cndims, dimids, cparent)
 
  If (cstatus == NC_NOERR) Then
@@ -1299,7 +1300,7 @@
     name         = stripCNullChar(cname, nlen)
     base_nf_type = c_base_nf_type
     base_size    = int(c_base_size)
-    num_members  = c_num_members
+    num_members  = int(c_num_members)
  EndIf
 
  status = cstatus
@@ -1443,7 +1444,7 @@
 
  If (cstatus == NC_NOERR) Then
     name   = stripCNullChar(cname, nlen)
-    isize  = csize
+    isize  = int(csize)
  EndIf
 
  status = cstatus
@@ -1862,7 +1863,7 @@
 
  If (cstatus == NC_NOERR) Then
    filterid = cfilterid
-   nparams = cnparams
+   nparams = int(cnparams)
    If (cnparams > 0) Then
      params(1:nparams) = cparams(1:nparams)
    EndIf
@@ -2004,7 +2005,7 @@
                                value)
 
  If (cstatus == NC_NOERR) Then
-    nlen = cnlen 
+    nlen = int(cnlen)
  EndIf
 
  status = cstatus

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -1468,7 +1468,7 @@
  Integer(C_INT) :: cncid, cvarid, ccontiguous, cstat1, cstatus, &
                    cndims
  Type(C_PTR)    :: cchunksizeptr
- Integer        :: i, ndims
+ Integer        :: ndims
 
  Integer(C_INT), ALLOCATABLE, TARGET :: cchunksizes(:)
 

--- a/fortran/nf_var1io.F90
+++ b/fortran/nf_var1io.F90
@@ -747,7 +747,7 @@
  Integer                                     :: status
 
  Integer(C_INT) :: cncid, cvarid, cndims, cstat1, cstatus
- Type(C_PTR)    :: cndexptr, cvaluesptr
+ Type(C_PTR)    :: cndexptr
  Integer        :: ndims
 
  Integer(C_SIZE_T), ALLOCATABLE, TARGET :: cndex(:)

--- a/nf_test/f90tst_parallel.F90
+++ b/nf_test/f90tst_parallel.F90
@@ -104,11 +104,11 @@ contains
   integer, parameter :: MAX_DIMS = 2
   integer, parameter :: NX = 16, NY = 16
   integer, parameter :: NUM_PROC = 4
-  integer :: ncid, varid, dimids(MAX_DIMS), chunksizes(MAX_DIMS), chunksizes_in(MAX_DIMS)
-  integer :: x_dimid, y_dimid, contig
+  integer :: ncid, varid, dimids(MAX_DIMS)
+  integer :: x_dimid, y_dimid
   integer :: data_out(NY / 2, NX / 2), data_in(NY / 2, NX / 2)
   integer :: nvars, ngatts, ndims, unlimdimid, file_format
-  integer :: x, y, retval
+  integer :: x, y
   integer :: my_rank, ierr
   integer :: start(MAX_DIMS), count(MAX_DIMS)
 

--- a/nf_test/f90tst_rengrps.f90
+++ b/nf_test/f90tst_rengrps.f90
@@ -10,7 +10,7 @@ program f90tst_rengrps
   ! We are writing 2D data, a 6 x 12 grid. 
   integer, parameter :: MAX_DIMS = 2
   integer, parameter :: NX = 6, NY = 12
-  integer :: chunksizes(MAX_DIMS), chunksizes_in(MAX_DIMS)
+  integer :: chunksizes(MAX_DIMS)
   integer, parameter :: CACHE_NELEMS = 10000, CACHE_SIZE = 1000000
   integer, parameter :: DEFLATE_LEVEL = 4
   ! We need these ids and other gunk for netcdf.
@@ -32,6 +32,8 @@ program f90tst_rengrps
   integer :: grpid1, grpid2
   integer :: xtype_in, ndims_in, natts_in, dimids_in(MAX_DIMS)
   character (len = nf90_max_name) :: name_in
+  integer :: chunksizes_in(MAX_DIMS)
+  integer :: x
 
   print *, ''
   print *,'*** Testing netCDF-4 rename groups from Fortran 90.'
@@ -73,9 +75,15 @@ program f90tst_rengrps
   if (name_in .ne. grp1_full_name) stop 62
 
   Call check(nf90_rename_grp(grpid1, NEW_GRP1_NAME))
-  name_in=REPEAT(" ",LEN(name_in))
+  name_in=REPEAT(" ", LEN(name_in))
   Call check(nf90_inq_grpname(grpid1, name_in))
   If (name_in /= NEW_GRP1_NAME) Call check(-1)
+
+  ! Check the vars, just for fun.
+  call check(nf90_inquire_variable(ncid, varid1, chunksizes = chunksizes_in))
+  do x = 1, size(chunksizes)
+     if (chunksizes(x) .ne. chunksizes_in(x)) stop 63
+  end do
 
   ! Close the file. 
   call check(nf90_close(ncid))

--- a/nf_test/f90tst_rengrps.f90
+++ b/nf_test/f90tst_rengrps.f90
@@ -16,7 +16,7 @@ program f90tst_rengrps
   ! We need these ids and other gunk for netcdf.
   integer :: ncid, varid1, varid2, dimids(MAX_DIMS)
   integer :: x_dimid, y_dimid
-  integer :: nvars, ngatts, ndims, unlimdimid, file_format
+  integer :: nvars, ngatts, ndims, unlimdimid
   character (len = *), parameter :: VAR1_NAME = "VarName1"
   character (len = *), parameter :: VAR2_NAME = "VarName2"
   character (len = *), parameter :: GRP1_NAME = "Old_Grp1_name"

--- a/nf_test/f90tst_vars2.f90
+++ b/nf_test/f90tst_vars2.f90
@@ -111,8 +111,8 @@ program f90tst_vars2
   if (chunksizes_in(1) /= chunksizes(1) .or. chunksizes_in(2) /= chunksizes(2)) &
        stop 4
   if (endianness_in .ne. nf90_endian_big) stop 5
-  print *, 'cache_size_in =', cache_size_in, 'cache_nelems_in =', cache_nelems_in, &
-       'cache_preemption_in =', cache_preemption
+  ! print *, 'cache_size_in =', cache_size_in, 'cache_nelems_in =', cache_nelems_in, &
+  !      'cache_preemption_in =', cache_preemption
 
   ! Check variable 2.
   call check(nf90_inquire_variable(ncid, varid2_in, name_in, xtype_in, ndims_in, dimids_in, &

--- a/nf_test/f90tst_vars2.f90
+++ b/nf_test/f90tst_vars2.f90
@@ -104,12 +104,15 @@ program f90tst_vars2
   ! Check variable 1.
   call check(nf90_inquire_variable(ncid, varid1_in, name_in, xtype_in, ndims_in, dimids_in, &
        natts_in, chunksizes = chunksizes_in, endianness = endianness_in, fletcher32 = fletcher32_in, &
-       deflate_level = deflate_level_in, shuffle = shuffle_in))
+       deflate_level = deflate_level_in, shuffle = shuffle_in, cache_size = cache_size_in, &
+       cache_nelems = cache_nelems_in, cache_preemption = cache_preemption_in))
   if (name_in .ne. VAR1_NAME .or. xtype_in .ne. NF90_INT .or. ndims_in .ne. MAX_DIMS .or. &
        natts_in .ne. 0 .or. dimids_in(1) .ne. dimids(1) .or. dimids_in(2) .ne. dimids(2)) stop 3
   if (chunksizes_in(1) /= chunksizes(1) .or. chunksizes_in(2) /= chunksizes(2)) &
        stop 4
   if (endianness_in .ne. nf90_endian_big) stop 5
+  print *, 'cache_size_in =', cache_size_in, 'cache_nelems_in =', cache_nelems_in, &
+       'cache_preemption_in =', cache_preemption
 
   ! Check variable 2.
   call check(nf90_inquire_variable(ncid, varid2_in, name_in, xtype_in, ndims_in, dimids_in, &

--- a/nf_test/f90tst_vars4.f90
+++ b/nf_test/f90tst_vars4.f90
@@ -18,7 +18,7 @@ program f90tst_vars4
 
   ! We need these ids and other gunk for netcdf.
   integer :: ncid, varid, dimids(MAX_DIMS), chunksizes(MAX_DIMS)
-  integer :: x_dimid, y_dimid, contig
+  integer :: x_dimid, y_dimid
   integer :: mode_flag
   integer :: nvars, ngatts, ndims, unlimdimid, file_format
   integer :: x, y

--- a/nf_test/tst_f90_nc4.f90
+++ b/nf_test/tst_f90_nc4.f90
@@ -2,7 +2,7 @@ program tst_f90_nc4
   use typeSizes
   use netcdf
   implicit none
-  integer :: fh, ierr, dimid, varid, ndim, nvar
+  integer :: fh, dimid, varid, ndim, nvar
   character (len = *), parameter :: FILE_NAME = "tst_f90_nc4.nc"
 
   print *, ''

--- a/nf_test/tst_io.f90
+++ b/nf_test/tst_io.f90
@@ -10,11 +10,11 @@ program tst_io
   implicit none
   integer, parameter :: prsz1 = 50, prsz2 = 50, &
        prsz3 = 50, prsz4 = 50, repct = 10
-  integer :: i1, i2, i3, i4, j, k, ticksPerSec
+  integer :: i1, i2, i3, i4, ticksPerSec
   real :: psr
   integer :: clockRate
   integer :: start, now, wrint1, ncint1, wrint2, ncint2, &
-       wrint3, ncint3, iosb, iosn, size
+       wrint3, iosb, size
   real, dimension (prsz1, prsz2, prsz3, prsz4) :: x
   character(len = *), parameter :: nclFilenm1 = 'tst_io1.nc', &
        nclFilenm2 = 'tst_io2.nc', nclFilenm3 = 'tst_io3.nc', &
@@ -24,7 +24,6 @@ program tst_io
        nclFilenm10 = 'tst_io10.nc', nclFilenm11 = 'tst_io11.nc'
   ! needed for netcdf
   integer :: ncid, x1id, x2id, x3id, x4id, vrid
-  integer :: vrids, vridt, vridu, vridv, vridw, vridx, vridy, vridz
 
   psr = 1.7/real(prsz1)
 


### PR DESCRIPTION
Fixes #146 
Part of #147.

In this PR I fix the problem of cache preemption being converted from float to int without multiplying by 100, resulting in a cache preemption of 0.

Also fixed many of the warnings in #147. Still some more to do.

This PR is ready to merge.