### PR TITLE
Fix for remaining parallel I/O tests

### DIFF
--- a/nf_test/Makefile.am
+++ b/nf_test/Makefile.am
@@ -106,15 +106,14 @@ endif #BUILD_BENCHMARKS
 # Test parallel I/O.
 if TEST_PARALLEL
 check_PROGRAMS += f90tst_parallel f90tst_parallel2 f90tst_parallel3	\
-f90tst_nc4_par
-#f90tst_parallel_fill
+f90tst_nc4_par f90tst_parallel_fill
 TESTS += run_f90_par_test.sh
 
 f90tst_parallel_SOURCES = f90tst_parallel.F90
 f90tst_parallel2_SOURCES = f90tst_parallel2.F90
 f90tst_parallel3_SOURCES = f90tst_parallel3.F90
 f90tst_nc4_par_SOURCES = f90tst_nc4_par.F90
-#f90tst_parallel_fill_SOURCES = f90tst_parallel_fill.f90
+f90tst_parallel_fill_SOURCES = f90tst_parallel_fill.f90
 endif # TEST_PARALLEL
 
 # Test parallel I/O for F77.

--- a/nf_test/f90tst_nc4_par.F90
+++ b/nf_test/f90tst_nc4_par.F90
@@ -47,7 +47,7 @@ contains
   implicit none
 
   character (len = *), parameter :: FILE_NAME = "f90tst_nc4_par.nc"
-  integer :: nmode, fill_mode, ierr, fh, my_task, nprocs, i, varid
+  integer :: nmode, fill_mode, ierr, fh, my_task, i, varid
   integer :: dimid(3), start(3), count(3)
   real :: f(3)
 

--- a/nf_test/f90tst_parallel3.F90
+++ b/nf_test/f90tst_parallel3.F90
@@ -123,7 +123,6 @@ contains
   integer :: x, y, v
   integer :: my_rank, ierr, old_mode
   integer :: start(MAX_DIMS), count(MAX_DIMS)
-  integer :: ret
 
   call MPI_Comm_rank(MPI_COMM_WORLD, my_rank, ierr)
 

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -121,10 +121,10 @@ program f90tst_parallel_fill
   call check(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
        info = MPI_INFO_NULL))
   
-!   ! Check some stuff out.
-!   call check(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
-!   if (ndims /= 2 .or. nvars /= NUM_VARS .or. ngatts /= 0 .or. unlimdimid /= 1 .or. &
-!        file_format /= nf90_format_netcdf4) stop 2
+! Check some stuff out.
+  call check(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
+  if (ndims /= 2 .or. nvars /= NUM_VARS .or. ngatts /= 0 .or. unlimdimid /= -1 .or. &
+       file_format /= nf90_format_netcdf4) stop 2
 
 !   ! Now each processor will read one quarter of the whole array.
 !   count_in = (/ HALF_NX, HALF_NY /)

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -140,13 +140,13 @@ program f90tst_parallel_fill
 
 ! Read this processor's data.
   call check(nf90_get_var(ncid, varid(1), byte_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(2), short_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(3), int_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(4), areal_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(5), double_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(6), ubyte_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(7), ushort_in, start = start_in, count = count_in))
-!   call check(nf90_get_var(ncid, varid(8), uint_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(2), short_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(3), int_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(4), areal_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(5), double_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(6), ubyte_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(7), ushort_in, start = start_in, count = count_in))
+  call check(nf90_get_var(ncid, varid(8), uint_in, start = start_in, count = count_in))
 
 !   ! Check the data. All the data from the processor zero are fill
 !   ! value.

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -126,20 +126,20 @@ program f90tst_parallel_fill
   if (ndims /= 2 .or. nvars /= NUM_VARS .or. ngatts /= 0 .or. unlimdimid /= -1 .or. &
        file_format /= nf90_format_netcdf4) stop 2
 
-!   ! Now each processor will read one quarter of the whole array.
-!   count_in = (/ HALF_NX, HALF_NY /)
-!   if (my_rank .eq. 0) then 
-!      start_in = (/ 1, 1 /)
-!   else if (my_rank .eq. 1) then
-!      start_in = (/ HALF_NX + 1, 1 /)
-!   else if (my_rank .eq. 2) then
-!      start_in = (/ 1, HALF_NY + 1 /)
-!   else if (my_rank .eq. 3) then
-!      start_in = (/ HALF_NX + 1, HALF_NY + 1 /)
-!   endif
+! Now each processor will read one quarter of the whole array.
+  count_in = (/ HALF_NX, HALF_NY /)
+  if (my_rank .eq. 0) then
+     start_in = (/ 1, 1 /)
+  else if (my_rank .eq. 1) then
+     start_in = (/ HALF_NX + 1, 1 /)
+  else if (my_rank .eq. 2) then
+     start_in = (/ 1, HALF_NY + 1 /)
+  else if (my_rank .eq. 3) then
+     start_in = (/ HALF_NX + 1, HALF_NY + 1 /)
+  endif
 
-!   ! Read this processor's data.
-!   call check(nf90_get_var(ncid, varid(1), byte_in, start = start_in, count = count_in))
+! Read this processor's data.
+  call check(nf90_get_var(ncid, varid(1), byte_in, start = start_in, count = count_in))
 !   call check(nf90_get_var(ncid, varid(2), short_in, start = start_in, count = count_in))
 !   call check(nf90_get_var(ncid, varid(3), int_in, start = start_in, count = count_in))
 !   call check(nf90_get_var(ncid, varid(4), areal_in, start = start_in, count = count_in))

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -37,6 +37,7 @@ program f90tst_parallel_fill
   integer :: x, y, v
   integer :: start_out(MAX_DIMS), count_out(MAX_DIMS)
   integer :: start_in(MAX_DIMS), count_in(MAX_DIMS)
+  integer :: mode
   integer :: p, my_rank, ierr
 
   call MPI_Init(ierr)
@@ -68,8 +69,9 @@ program f90tst_parallel_fill
      end do
   end do
 
-  ! Create the netCDF file. 
-  call check(nf90_create(FILE_NAME, nf90_netcdf4, ncid, comm = MPI_COMM_WORLD, &
+  ! Create the netCDF file.
+  mode = ior(nf90_netcdf4, nf90_mpiio)
+  call check(nf90_create(FILE_NAME, mode, ncid, comm = MPI_COMM_WORLD, &
        info = MPI_INFO_NULL))
 
   ! Define the dimensions.
@@ -118,7 +120,8 @@ program f90tst_parallel_fill
   call check(nf90_close(ncid))
 
   ! Reopen the file.
-  call check(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
+  mode = ior(nf90_nowrite, nf90_mpiio)
+  call check(nf90_open(FILE_NAME, mode, ncid, comm = MPI_COMM_WORLD, &
        info = MPI_INFO_NULL))
   
   ! Check some stuff out.

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -2,9 +2,12 @@
 !     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
 !     See COPYRIGHT file for conditions of use.
 
-!     This program tests netCDF-4 fill values.
+!     This program tests netCDF-4 fill values with parallel I/O. It
+!     writes a checkerboard decomposition for a number of variables,
+!     but task 0 (of 4) does not write. The resulting data has fill
+!     value for the first quarter of each array.
 
-!     $Id: f90tst_parallel_fill.f90,v 1.1 2009/12/10 16:44:51 ed Exp $
+!     Ed Hartnett, started 2009, finished 2019.
 
 program f90tst_parallel_fill
   use typeSizes
@@ -46,7 +49,7 @@ program f90tst_parallel_fill
 
   if (my_rank .eq. 0) then
      print *,
-     print *, '*** Testing fill values with unlimited dimension and parallel I/O.'
+     print *, '*** Testing fill values with parallel I/O.'
   endif
 
   ! There must be 4 procs for this test.
@@ -69,7 +72,8 @@ program f90tst_parallel_fill
      end do
   end do
 
-  ! Create the netCDF file.
+  ! Create the netCDF file. nf90_mpiio flag not required starting with
+  ! netcdf-c-4.6.1.
   mode = ior(nf90_netcdf4, nf90_mpiio)
   call check(nf90_create(FILE_NAME, mode, ncid, comm = MPI_COMM_WORLD, &
        info = MPI_INFO_NULL))
@@ -119,7 +123,8 @@ program f90tst_parallel_fill
   ! Close the file. 
   call check(nf90_close(ncid))
 
-  ! Reopen the file.
+  ! Reopen the file. nf90_mpiio flag not required starting with
+  ! netcdf-c-4.6.1.
   mode = ior(nf90_nowrite, nf90_mpiio)
   call check(nf90_open(FILE_NAME, mode, ncid, comm = MPI_COMM_WORLD, &
        info = MPI_INFO_NULL))

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -118,8 +118,8 @@ program f90tst_parallel_fill
   call check(nf90_close(ncid))
 
   ! Reopen the file.
-!   call check(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
-!        info = MPI_INFO_NULL))
+  call check(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
+       info = MPI_INFO_NULL))
   
 !   ! Check some stuff out.
 !   call check(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
@@ -174,8 +174,8 @@ program f90tst_parallel_fill
 !      end do
 !   end do
 
-!   ! Close the file. 
-!   call check(nf90_close(ncid))
+! Close the file.
+  call check(nf90_close(ncid))
 
   call MPI_Finalize(ierr)
 

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -25,14 +25,14 @@ program f90tst_parallel_fill
   integer :: var_type(NUM_VARS) = (/ nf90_byte, nf90_short, nf90_int, &
        nf90_float, nf90_double, nf90_ubyte, nf90_ushort, nf90_uint /)
   integer :: x_dimid, y_dimid
-  integer :: byte_out(HALF_NY, HALF_NX), byte_in(NY, NX)
-  integer :: short_out(HALF_NY, HALF_NX), short_in(NY, NX)
-  integer :: int_out(HALF_NY, HALF_NX), int_in(NY, NX)
-  real :: areal_out(HALF_NY, HALF_NX), areal_in(NY, NX)
-  real :: double_out(HALF_NY, HALF_NX), double_in(NY, NX)
-  integer :: ubyte_out(HALF_NY, HALF_NX), ubyte_in(NY, NX)
-  integer :: ushort_out(HALF_NY, HALF_NX), ushort_in(NY, NX)
-  integer (kind = EightByteInt) :: uint_out(HALF_NY, HALF_NX), uint_in(NY, NX)
+  integer :: byte_out(HALF_NY, HALF_NX), byte_in(HALF_NY, HALF_NX)
+  integer :: short_out(HALF_NY, HALF_NX), short_in(HALF_NY, HALF_NX)
+  integer :: int_out(HALF_NY, HALF_NX), int_in(HALF_NY, HALF_NX)
+  real :: areal_out(HALF_NY, HALF_NX), areal_in(HALF_NY, HALF_NX)
+  real :: double_out(HALF_NY, HALF_NX), double_in(HALF_NY, HALF_NX)
+  integer :: ubyte_out(HALF_NY, HALF_NX), ubyte_in(HALF_NY, HALF_NX)
+  integer :: ushort_out(HALF_NY, HALF_NX), ushort_in(HALF_NY, HALF_NX)
+  integer (kind = EightByteInt) :: uint_out(HALF_NY, HALF_NX), uint_in(HALF_NY, HALF_NX)
   integer :: nvars, ngatts, ndims, unlimdimid, file_format
   integer :: x, y, v
   integer :: start_out(MAX_DIMS), count_out(MAX_DIMS)
@@ -102,7 +102,7 @@ program f90tst_parallel_fill
   else if (my_rank .eq. 3) then
      start_out = (/ HALF_NX + 1, HALF_NY + 1 /)
   endif
-  print *, my_rank, start_out, count_out
+  ! print *, my_rank, start_out, count_out
 
   ! Write this processor's data, except for processor zero.
   call check(nf90_put_var(ncid, varid(1), byte_out, start = start_out, count = count_out))
@@ -121,12 +121,12 @@ program f90tst_parallel_fill
   call check(nf90_open(FILE_NAME, nf90_nowrite, ncid, comm = MPI_COMM_WORLD, &
        info = MPI_INFO_NULL))
   
-! Check some stuff out.
+  ! Check some stuff out.
   call check(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
   if (ndims /= 2 .or. nvars /= NUM_VARS .or. ngatts /= 0 .or. unlimdimid /= -1 .or. &
        file_format /= nf90_format_netcdf4) stop 2
 
-! Now each processor will read one quarter of the whole array.
+  ! Now each processor will read one quarter of the whole array.
   count_in = (/ HALF_NX, HALF_NY /)
   if (my_rank .eq. 0) then
      start_in = (/ 1, 1 /)
@@ -138,7 +138,7 @@ program f90tst_parallel_fill
      start_in = (/ HALF_NX + 1, HALF_NY + 1 /)
   endif
 
-! Read this processor's data.
+  ! Read this processor's data.
   call check(nf90_get_var(ncid, varid(1), byte_in, start = start_in, count = count_in))
   call check(nf90_get_var(ncid, varid(2), short_in, start = start_in, count = count_in))
   call check(nf90_get_var(ncid, varid(3), int_in, start = start_in, count = count_in))
@@ -148,31 +148,31 @@ program f90tst_parallel_fill
   call check(nf90_get_var(ncid, varid(7), ushort_in, start = start_in, count = count_in))
   call check(nf90_get_var(ncid, varid(8), uint_in, start = start_in, count = count_in))
 
-!   ! Check the data. All the data from the processor zero are fill
-!   ! value.
-!   do x = 1, NX
-!      do y = 1, NY
-!         if (my_rank .eq. 0) then
-!            if (byte_in(y, x) .ne. -1) stop 13
-!            if (short_in(y, x) .ne. -2) stop 14
-!            if (int_in(y, x) .ne. -4) stop 15
-!            if (areal_in(y, x) .ne. 2.5) stop 16
-!            if (double_in(y, x) .ne. -4.5) stop 17
-!            if (ubyte_in(y, x) .ne. 1) stop 18
-!            if (ushort_in(y, x) .ne. 2) stop 19
-!            if (uint_in(y, x) .ne. 4) stop 20
-!         else 
-!            if (byte_in(y, x) .ne. nf90_fill_byte) stop 3
-!            if (short_in(y, x) .ne. nf90_fill_short) stop 4
-!            if (int_in(y, x) .ne. nf90_fill_int) stop 5
-!            if (areal_in(y, x) .ne. nf90_fill_real) stop 6
-!            if (double_in(y, x) .ne. nf90_fill_double) stop 7
-!            if (ubyte_in(y, x) .ne. nf90_fill_ubyte) stop 8
-!            if (ushort_in(y, x) .ne. nf90_fill_ushort) stop 9
-!            if (uint_in(y, x) .ne. nf90_fill_uint) stop 10
-!         endif
-!      end do
-!   end do
+  ! Check the data. All the data from the processor zero are fill
+  ! value.
+  do x = 1, HALF_NX
+     do y = 1, HALF_NY
+        if (my_rank .ne. 0) then
+           if (byte_in(y, x) .ne. -1) stop 13
+           if (short_in(y, x) .ne. -2) stop 14
+           if (int_in(y, x) .ne. -4) stop 15
+           if (areal_in(y, x) .ne. 2.5) stop 16
+           if (double_in(y, x) .ne. -4.5) stop 17
+           if (ubyte_in(y, x) .ne. 1) stop 18
+           if (ushort_in(y, x) .ne. 2) stop 19
+           if (uint_in(y, x) .ne. 4) stop 20
+        else
+           if (byte_in(y, x) .ne. nf90_fill_byte) stop 3
+           if (short_in(y, x) .ne. nf90_fill_short) stop 4
+           if (int_in(y, x) .ne. nf90_fill_int) stop 5
+           if (areal_in(y, x) .ne. nf90_fill_real) stop 6
+           if (double_in(y, x) .ne. nf90_fill_double) stop 7
+           if (ubyte_in(y, x) .ne. nf90_fill_ubyte) stop 8
+           if (ushort_in(y, x) .ne. nf90_fill_ushort) stop 9
+           if (uint_in(y, x) .ne. nf90_fill_uint) stop 10
+        endif
+     end do
+  end do
 
 ! Close the file.
   call check(nf90_close(ncid))

--- a/nf_test/f90tst_parallel_fill.f90
+++ b/nf_test/f90tst_parallel_fill.f90
@@ -25,14 +25,14 @@ program f90tst_parallel_fill
   integer :: var_type(NUM_VARS) = (/ nf90_byte, nf90_short, nf90_int, &
        nf90_float, nf90_double, nf90_ubyte, nf90_ushort, nf90_uint /)
   integer :: x_dimid, y_dimid
-  integer :: byte_out(QUARTER_NY, QUARTER_NX), byte_in(NY, NX)
-  integer :: short_out(QUARTER_NY, QUARTER_NX), short_in(NY, NX)
-  integer :: int_out(QUARTER_NY, QUARTER_NX), int_in(NY, NX)
-  real :: areal_out(QUARTER_NY, QUARTER_NX), areal_in(NY, NX)
-  real :: double_out(QUARTER_NY, QUARTER_NX), double_in(NY, NX)
-  integer :: ubyte_out(QUARTER_NY, QUARTER_NX), ubyte_in(NY, NX)
-  integer :: ushort_out(QUARTER_NY, QUARTER_NX), ushort_in(NY, NX)
-  integer (kind = EightByteInt) :: uint_out(QUARTER_NY, QUARTER_NX), uint_in(NY, NX)
+  integer :: byte_out(HALF_NY, HALF_NX), byte_in(NY, NX)
+  integer :: short_out(HALF_NY, HALF_NX), short_in(NY, NX)
+  integer :: int_out(HALF_NY, HALF_NX), int_in(NY, NX)
+  real :: areal_out(HALF_NY, HALF_NX), areal_in(NY, NX)
+  real :: double_out(HALF_NY, HALF_NX), double_in(NY, NX)
+  integer :: ubyte_out(HALF_NY, HALF_NX), ubyte_in(NY, NX)
+  integer :: ushort_out(HALF_NY, HALF_NX), ushort_in(NY, NX)
+  integer (kind = EightByteInt) :: uint_out(HALF_NY, HALF_NX), uint_in(NY, NX)
   integer :: nvars, ngatts, ndims, unlimdimid, file_format
   integer :: x, y, v
   integer :: start_out(MAX_DIMS), count_out(MAX_DIMS)
@@ -55,8 +55,8 @@ program f90tst_parallel_fill
   endif
 
   ! Create some pretend data.
-  do x = 1, QUARTER_NX
-     do y = 1, QUARTER_NY
+  do x = 1, HALF_NX
+     do y = 1, HALF_NY
         byte_out(y, x) = -1
         short_out(y, x) =  -2
         int_out(y, x) = -4
@@ -91,29 +91,28 @@ program f90tst_parallel_fill
   ! quadrant of data will be written, so each processor writes a
   ! quarter of the quadrant, or 1/16th of the total array. (And
   ! processor 0 doesn't write anyway.)
-  count_out = (/ QUARTER_NX, QUARTER_NY /)
-  if (my_rank .eq. 0) then 
-     start_out = (/ HALF_NX + 1, HALF_NY + 1 /)
+  count_out = (/ HALF_NX, HALF_NY /)
+  if (my_rank .eq. 0) then
+     start_out = (/ 1, 1 /)
+     count_out = (/ 0, 0 /)
   else if (my_rank .eq. 1) then
-     start_out = (/ HALF_NX + 1, HALF_NY + 1 + QUARTER_NY /)
+     start_out = (/ HALF_NX + 1, 1 /)
   else if (my_rank .eq. 2) then
-     start_out = (/ HALF_NX + 1 + QUARTER_NX, HALF_NY + 1 /)
+     start_out = (/ 1, HALF_NY + 1 /)
   else if (my_rank .eq. 3) then
-     start_out = (/ HALF_NX + 1 + QUARTER_NX, HALF_NY + 1 + QUARTER_NY /)
+     start_out = (/ HALF_NX + 1, HALF_NY + 1 /)
   endif
   print *, my_rank, start_out, count_out
 
   ! Write this processor's data, except for processor zero.
-  if (my_rank .ne. 0) then
-     call check(nf90_put_var(ncid, varid(1), byte_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(2), short_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(3), int_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(4), areal_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(5), double_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(6), ubyte_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(7), ushort_out, start = start_out, count = count_out))
-!      call check(nf90_put_var(ncid, varid(8), uint_out, start = start_out, count = count_out))
-  endif
+  call check(nf90_put_var(ncid, varid(1), byte_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(2), short_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(3), int_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(4), areal_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(5), double_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(6), ubyte_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(7), ushort_out, start = start_out, count = count_out))
+  call check(nf90_put_var(ncid, varid(8), uint_out, start = start_out, count = count_out))
 
   ! Close the file. 
   call check(nf90_close(ncid))

--- a/nf_test/run_f90_par_test.sh
+++ b/nf_test/run_f90_par_test.sh
@@ -8,7 +8,7 @@ mpiexec -n 4 ./f90tst_parallel
 mpiexec -n 4 ./f90tst_parallel2
 mpiexec -n 4 ./f90tst_parallel3
 mpiexec -n 8 ./f90tst_nc4_par
-#mpiexec -n 4 ./f90tst_parallel_fill
+mpiexec -n 4 ./f90tst_parallel_fill
 
 echo "SUCCESS!!!"
 exit 0


### PR DESCRIPTION
Fixes #162.
Fixes #134.

In this PR I finish a test program I started in 2009 and left incomplete - nf_test/f90tst_parallel_fill.f90, which tests fill values in parallel I/O reads and writes.

Also fixed failures relating to removal of nf_mpiio flag. We still need to use this flag in our tests, if we want to work with older versions of netcdf-c. I am testing from netcdf-c-4.6.0 onwards.

