### PR TITLE
fix dependency tracking in fortran directory, enabling parallel (make -j) builds

### DIFF
--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -5,8 +5,7 @@
 
 # Ed Hartnett, Russ Rew, Dennis Heimbigner, Ward Fisher
 
-# Turn off parallel builds in this directory.
-.NOTPARALLEL:
+AM_FCFLAGS = -I.
 
 # This is what we are building: the netCDF fortran library, containing
 # the F77 and the F90 APIs.
@@ -16,15 +15,6 @@ lib_LTLIBRARIES = libnetcdff.la
 # See http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 # for information regarding incrementing `-version-info`.
 libnetcdff_la_LDFLAGS = -version-info 6:1:1
-
-# This, plus either netcdf4.f90 or netcdf.f90, is the main source.
-libnetcdff_la_SOURCES = typeSizes.f90
-
-if USE_NETCDF4
-NETCDF_O = netcdf4.$(OBJEXT)
-else
-NETCDF_O = netcdf.$(OBJEXT)
-endif
 
 # These f90 codes are used for either netCDF classic or netCDF-4 F90
 # API.
@@ -38,82 +28,201 @@ NETCDF4_CODES = netcdf4_externals.f90 netcdf4_visibility.f90	\
 netcdf4_func.f90 netcdf4_overloads.f90 netcdf4_file.f90		\
 netcdf4_eightbyte.f90 netcdf4_variables.f90
 
-# Add dependencies for source files included in "meta" source files,
-# so the meta source is rebuilt properly when an included file is
-# modified.
-netcdf.$(OBJEXT): $(COMMON_CODES) netcdf3_file.f90
-netcdf4.$(OBJEXT): $(COMMON_CODES) $(NETCDF4_CODES)
+# Build these uninstalled convenience libraries.
+noinst_LTLIBRARIES = libtypeSizes.la libnetcdf_nc_data.la	\
+libnetcdf_nf_data.la libnetcdf_nc_interfaces.la			\
+libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
 
-# Modules and source for the F77 API.
-libnetcdff_la_SOURCES += module_netcdf_nc_data.F90			\
-module_netcdf_nc_interfaces.f90 module_netcdf_nf_data.F90		\
-module_netcdf_nf_interfaces.F90 module_netcdf_f03.f90 nf_attio.F90	\
-nf_control.F90 nf_dim.f90 nf_misc.f90 nf_genatt.f90 nf_geninq.f90	\
-nf_genvar.f90 nf_vario.F90 nf_var1io.F90 nf_varaio.F90 nf_varmio.F90	\
-nf_varsio.F90
-
-# Add netCDF-4 to F77 API if needed.
+# Different source for the netcdf.mod is used for netcdf classic
+# vs. netcdf4.
 if USE_NETCDF4
-libnetcdff_la_SOURCES += module_netcdf4_nc_interfaces.f90		\
-module_netcdf4_nf_interfaces.F90 module_netcdf4_f03.f90 nf_lib.c	\
-nf_nc4.f90
-endif USE_NETCDF4
+libnetcdfm_la_SOURCES = netcdf4.f90
+netcdf4.$(OBJECT): typeSizes.mod
+netcdf.mod: netcdf4.$(OBJEXT)
+EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES)
+else # classic-only build
+libnetcdfm_la_SOURCES = netcdf.f90
+netcdf.$(OBJECT): typeSizes.mod
+netcdf.mod: netcdf.$(OBJEXT)
+EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES) $(NETCDF4_CODES)
+endif # USE_NETCDF4
 
-# Add nf_logging to F77 API if needed.
-if USE_LOGGING
-libnetcdff_la_SOURCES += nf_logging.F90
-endif USE_LOGGING
+# Each convenience library depends on its source.
+libtypeSizes_la_SOURCES = typeSizes.f90
+libnetcdf_nc_data_la_SOURCES = module_netcdf_nc_data.f90
+libnetcdf_nf_data_la_SOURCES = module_netcdf_nf_data.f90
+libnetcdf_nc_interfaces_la_SOURCES = module_netcdf_nc_interfaces.f90
+libnetcdf_nf_interfaces_la_SOURCES = module_netcdf_nf_interfaces.f90
+libnetcdf_f03_la_SOURCES = module_netcdf_f03.f90
 
-# The file netcdf.f90 includes all these code files.
-libnetcdff_la_DEPENDENCIES = $(COMMON_CODES)
-
-if USE_NETCDF4
-libnetcdff_la_SOURCES += netcdf4.f90
-libnetcdff_la_DEPENDENCIES += $(NETCDF4_CODES)
-else !USE_NETCDF4
-libnetcdff_la_SOURCES += netcdf.f90 netcdf3_file.f90
-endif !USE_NETCDF4
-
-# Add the V2 F77 API.
-if BUILD_V2
-libnetcdff_la_SOURCES += nf_v2compat.c			\
-module_netcdf_fortv2_c_interfaces.f90 nf_fortv2.f90
-endif
-
-# These mod files for the F77 API are always built.
-MODFILES = typesizes.mod netcdf.mod netcdf_nc_data.mod			\
-netcdf_nc_interfaces.mod netcdf_nf_data.mod netcdf_nf_interfaces.mod	\
-netcdf_f03.mod
-
-# Mod files are dependant on their source.
-netcdf.mod: $(NETCDF_O)
-typesizes.mod: typeSizes.$(OBJEXT)
+# Each mod file depends on the .o file.
+typeSizes.mod: typeSizes.$(OBJEXT)
 netcdf_nc_data.mod: module_netcdf_nc_data.$(OBJEXT)
-netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.$(OBJEXT)
 netcdf_nf_data.mod: module_netcdf_nf_data.$(OBJEXT)
+netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.$(OBJEXT)
 netcdf_nf_interfaces.mod: module_netcdf_nf_interfaces.$(OBJEXT)
 netcdf_f03.mod: module_netcdf_f03.$(OBJEXT)
 
-# If v2 API is being built, build v2 F77 API mod file.
-if BUILD_V2
-MODFILES += netcdf_fortv2_c_interfaces.mod
-netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.$(OBJEXT) netcdf_nc_interfaces.mod
-endif BUILD_V2
+# Some mods are dependant on other mods in this dir.
+module_netcdf_nf_data.$(OBJEXT): netcdf_nc_data.mod
+module_netcdf_nc_interfaces.$(OBJEXT): netcdf_nc_data.mod
+module_netcdf_nf_interfaces.$(OBJEXT): netcdf_nf_data.mod
+module_netcdf_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod
 
-# If netCDF-4 is being build, build the netCDF-4 F77 API mod files.
+# Mod files are built and then installed as headers. Order is
+# significant in this list of modfiles.
+MODFILES = typeSizes.mod netcdf_nc_data.mod netcdf_nf_data.mod	\
+netcdf_nc_interfaces.mod netcdf_nf_interfaces.mod
+
+# Add our convenience libraries to the netCDF fortran library.
+libnetcdff_la_LIBADD = libtypeSizes.la libnetcdf_nc_data.la	\
+libnetcdf_nf_data.la libnetcdf_nc_interfaces.la			\
+libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
+
+# These are the ource for the F77 API.
+libnetcdff_la_SOURCES = nf_attio.F90 nf_control.F90 nf_dim.f90		\
+nf_misc.f90 nf_genatt.f90 nf_geninq.f90 nf_genvar.f90 nf_vario.F90	\
+nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90
+
+# Add the V2 F77 API.
+if BUILD_V2
+noinst_LTLIBRARIES += libnetcdf_fortv2_c_interfaces.la
+libnetcdf_fortv2_c_interfaces_la_SOURCES = module_netcdf_fortv2_c_interfaces.f90
+netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.$(OBJEXT)
+module_netcdf_fortv2_c_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
+MODFILES += netcdf_fortv2_c_interfaces.mod
+libnetcdff_la_SOURCES += nf_v2compat.c nf_fortv2.f90
+libnetcdff_la_LIBADD += libnetcdf_fortv2_c_interfaces.la
+endif # BUILD_V2
+
+# Are we building netCDF-4?
 if USE_NETCDF4
-MODFILES += netcdf4_nc_interfaces.mod netcdf4_nf_interfaces.mod	\
-netcdf4_f03.mod
-netcdf4_nc_interfaces.mod: module_netcdf4_nc_interfaces.$(OBJEXT) netcdf_nc_interfaces.mod
+
+# Add additional source files to the library to support netCDF4.
+libnetcdff_la_SOURCES += nf_lib.c nf_nc4.f90
+
+# Add the code that implements the F90 API.
+# libnetcdff_la_DEPENDENCIES = netcdf4_externals.f90		\
+# netcdf4_visibility.f90 netcdf4_func.f90 netcdf4_overloads.f90	\
+# netcdf4_file.f90 netcdf4_eightbyte.f90 netcdf4_variables.f90
+
+# Add these uninstalled convenience libraries for netcdf-4.
+noinst_LTLIBRARIES += libnetcdf4_nc_interfaces.la	\
+libnetcdf4_nf_interfaces.la libnetcdf4_f03.la
+
+# Each convenience library depends on its source.
+libnetcdf4_nc_interfaces_la_SOURCES = module_netcdf4_nc_interfaces.f90
+libnetcdf4_nf_interfaces_la_SOURCES = module_netcdf4_nf_interfaces.f90
+libnetcdf4_f03_la_SOURCES = module_netcdf4_f03.f90
+
+# Each mod file depends on the .o file.
+netcdf4_nc_interfaces.mod: module_netcdf4_nc_interfaces.$(OBJEXT)
 netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.$(OBJEXT)
 netcdf4_f03.mod: module_netcdf4_f03.$(OBJEXT)
-endif USE_NETCDF4
 
-# The mod files and the netcdf.inc file are built on the user machine,
-# and installed as headers.
-BUILT_SOURCES = $(MODFILES) netcdf.inc
-nodist_include_HEADERS = $(MODFILES) netcdf.inc
-libnetcdff_la_DEPENDENCIES += $(MODFILES) netcdf.inc
+# Some mods are dependant on other mods in this dir.
+module_netcdf4_nc_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
+module_netcdf4_nf_interfaces.$(OBJEXT): netcdf4_nc_interfaces.mod
+module_netcdf4_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod netcdf4_nf_interfaces.mod
+
+# Add the netcdf4 mod files to the list.
+MODFILES += netcdf4_nc_interfaces.mod netcdf4_nf_interfaces.mod	\
+netcdf4_f03.mod
+
+# Add the netcdf4 convenience libraries to the netcdf fortran library.
+libnetcdff_la_LIBADD += libnetcdf4_nc_interfaces.la	\
+libnetcdf4_nf_interfaces.la libnetcdf4_f03.la
+
+endif # USE_NETCDF4
+
+MODFILES += netcdf.mod
+
+# Mod files are installed as headers, and are built sources.
+include_HEADERS = $(MODFILES)
+BUILT_SOURCES = $(MODFILES)
+
+# if USE_NETCDF4
+# NETCDF_O = netcdf4.$(OBJEXT)
+# else
+# NETCDF_O = netcdf.$(OBJEXT)
+# endif
+
+
+# # Add dependencies for source files included in "meta" source files,
+# # so the meta source is rebuilt properly when an included file is
+# # modified.
+# netcdf.$(OBJEXT): $(COMMON_CODES) netcdf3_file.f90
+# netcdf4.$(OBJEXT): $(COMMON_CODES) $(NETCDF4_CODES)
+
+# # Modules and source for the F77 API.
+# libnetcdff_la_SOURCES += module_netcdf_nc_data.F90			\
+# module_netcdf_nc_interfaces.f90 module_netcdf_nf_data.F90		\
+# module_netcdf_nf_interfaces.F90 module_netcdf_f03.f90 nf_attio.F90	\
+# nf_control.F90 nf_dim.f90 nf_misc.f90 nf_genatt.f90 nf_geninq.f90	\
+# nf_genvar.f90 nf_vario.F90 nf_var1io.F90 nf_varaio.F90 nf_varmio.F90	\
+# nf_varsio.F90
+
+# # Add netCDF-4 to F77 API if needed.
+# if USE_NETCDF4
+# libnetcdff_la_SOURCES += module_netcdf4_nc_interfaces.f90		\
+# module_netcdf4_nf_interfaces.F90 module_netcdf4_f03.f90 nf_lib.c	\
+# nf_nc4.f90
+# endif USE_NETCDF4
+
+# # Add nf_logging to F77 API if needed.
+# if USE_LOGGING
+# libnetcdff_la_SOURCES += nf_logging.F90
+# endif USE_LOGGING
+
+# # The file netcdf.f90 includes all these code files.
+# libnetcdff_la_DEPENDENCIES = $(COMMON_CODES)
+
+# if USE_NETCDF4
+# libnetcdff_la_SOURCES += netcdf4.f90
+# libnetcdff_la_DEPENDENCIES += $(NETCDF4_CODES)
+# else !USE_NETCDF4
+# libnetcdff_la_SOURCES += netcdf.f90 netcdf3_file.f90
+# endif !USE_NETCDF4
+
+# # Add the V2 F77 API.
+# if BUILD_V2
+# libnetcdff_la_SOURCES += nf_v2compat.c			\
+# module_netcdf_fortv2_c_interfaces.f90 nf_fortv2.f90
+# endif
+
+# # These mod files for the F77 API are always built.
+# MODFILES = typesizes.mod netcdf.mod netcdf_nc_data.mod			\
+# netcdf_nc_interfaces.mod netcdf_nf_data.mod netcdf_nf_interfaces.mod	\
+# netcdf_f03.mod
+
+# # Mod files are dependant on their source.
+# netcdf.mod: $(NETCDF_O)
+# typesizes.mod: typeSizes.$(OBJEXT)
+# netcdf_nc_data.mod: module_netcdf_nc_data.$(OBJEXT)
+# netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.$(OBJEXT)
+# netcdf_nf_data.mod: module_netcdf_nf_data.$(OBJEXT)
+# netcdf_nf_interfaces.mod: module_netcdf_nf_interfaces.$(OBJEXT)
+# netcdf_f03.mod: module_netcdf_f03.$(OBJEXT)
+
+# # If v2 API is being built, build v2 F77 API mod file.
+# if BUILD_V2
+# MODFILES += netcdf_fortv2_c_interfaces.mod
+# netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.$(OBJEXT) netcdf_nc_interfaces.mod
+# endif BUILD_V2
+
+# # If netCDF-4 is being build, build the netCDF-4 F77 API mod files.
+# if USE_NETCDF4
+# MODFILES += netcdf4_nc_interfaces.mod netcdf4_nf_interfaces.mod	\
+# netcdf4_f03.mod
+# netcdf4_nc_interfaces.mod: module_netcdf4_nc_interfaces.$(OBJEXT) netcdf_nc_interfaces.mod
+# netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.$(OBJEXT)
+# netcdf4_f03.mod: module_netcdf4_f03.$(OBJEXT)
+# endif USE_NETCDF4
+
+# The netcdf.inc file is built on the user machine, and installed as
+# a header.
+BUILT_SOURCES += netcdf.inc
+include_HEADERS += netcdf.inc
 
 # Build netcdf.inc file from netcdf2, netcdf3 and netcdf4 files
 netcdf.inc: netcdf2.inc netcdf3.inc netcdf4.inc
@@ -136,7 +245,8 @@ if USE_LOGGING
 	echo '      external nf_set_log_level' >> netcdf.inc
 endif
 
-EXTRA_DIST = $(COMMON_CODES) $(NETCDF4_CODES) CMakeLists.txt	\
-netcdf2.inc netcdf3.inc netcdf4.inc
+# EXTRA_DIST = $(COMMON_CODES) $(NETCDF4_CODES) CMakeLists.txt	\
+# netcdf2.inc netcdf3.inc netcdf4.inc
+EXTRA_DIST = CMakeLists.txt netcdf2.inc netcdf3.inc netcdf4.inc
 
 CLEANFILES = *.mod netcdf.inc

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -102,11 +102,6 @@ if USE_NETCDF4
 # Add additional source files to the library to support netCDF4.
 libnetcdff_la_SOURCES += nf_lib.c nf_nc4.f90
 
-# Add the code that implements the F90 API.
-# libnetcdff_la_DEPENDENCIES = netcdf4_externals.f90		\
-# netcdf4_visibility.f90 netcdf4_func.f90 netcdf4_overloads.f90	\
-# netcdf4_file.f90 netcdf4_eightbyte.f90 netcdf4_variables.f90
-
 # Add these uninstalled convenience libraries for netcdf-4.
 noinst_LTLIBRARIES += libnetcdf4_nc_interfaces.la	\
 libnetcdf4_nf_interfaces.la libnetcdf4_f03.la
@@ -144,84 +139,6 @@ BUILT_SOURCES = $(MODFILES)
 
 # Mod files are installed as headers, but not distrubuted.
 nodist_include_HEADERS = $(MODFILES)
-
-# if USE_NETCDF4
-# NETCDF_O = netcdf4.$(OBJEXT)
-# else
-# NETCDF_O = netcdf.$(OBJEXT)
-# endif
-
-
-# # Add dependencies for source files included in "meta" source files,
-# # so the meta source is rebuilt properly when an included file is
-# # modified.
-# netcdf.$(OBJEXT): $(COMMON_CODES) netcdf3_file.f90
-# netcdf4.$(OBJEXT): $(COMMON_CODES) $(NETCDF4_CODES)
-
-# # Modules and source for the F77 API.
-# libnetcdff_la_SOURCES += module_netcdf_nc_data.F90			\
-# module_netcdf_nc_interfaces.f90 module_netcdf_nf_data.F90		\
-# module_netcdf_nf_interfaces.F90 module_netcdf_f03.f90 nf_attio.F90	\
-# nf_control.F90 nf_dim.f90 nf_misc.f90 nf_genatt.f90 nf_geninq.f90	\
-# nf_genvar.f90 nf_vario.F90 nf_var1io.F90 nf_varaio.F90 nf_varmio.F90	\
-# nf_varsio.F90
-
-# # Add netCDF-4 to F77 API if needed.
-# if USE_NETCDF4
-# libnetcdff_la_SOURCES += module_netcdf4_nc_interfaces.f90		\
-# module_netcdf4_nf_interfaces.F90 module_netcdf4_f03.f90 nf_lib.c	\
-# nf_nc4.f90
-# endif USE_NETCDF4
-
-# # Add nf_logging to F77 API if needed.
-# if USE_LOGGING
-# libnetcdff_la_SOURCES += nf_logging.F90
-# endif USE_LOGGING
-
-# # The file netcdf.f90 includes all these code files.
-# libnetcdff_la_DEPENDENCIES = $(COMMON_CODES)
-
-# if USE_NETCDF4
-# libnetcdff_la_SOURCES += netcdf4.f90
-# libnetcdff_la_DEPENDENCIES += $(NETCDF4_CODES)
-# else !USE_NETCDF4
-# libnetcdff_la_SOURCES += netcdf.f90 netcdf3_file.f90
-# endif !USE_NETCDF4
-
-# # Add the V2 F77 API.
-# if BUILD_V2
-# libnetcdff_la_SOURCES += nf_v2compat.c			\
-# module_netcdf_fortv2_c_interfaces.f90 nf_fortv2.f90
-# endif
-
-# # These mod files for the F77 API are always built.
-# MODFILES = typesizes.mod netcdf.mod netcdf_nc_data.mod			\
-# netcdf_nc_interfaces.mod netcdf_nf_data.mod netcdf_nf_interfaces.mod	\
-# netcdf_f03.mod
-
-# # Mod files are dependant on their source.
-# netcdf.mod: $(NETCDF_O)
-# typesizes.mod: typeSizes.$(OBJEXT)
-# netcdf_nc_data.mod: module_netcdf_nc_data.$(OBJEXT)
-# netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.$(OBJEXT)
-# netcdf_nf_data.mod: module_netcdf_nf_data.$(OBJEXT)
-# netcdf_nf_interfaces.mod: module_netcdf_nf_interfaces.$(OBJEXT)
-# netcdf_f03.mod: module_netcdf_f03.$(OBJEXT)
-
-# # If v2 API is being built, build v2 F77 API mod file.
-# if BUILD_V2
-# MODFILES += netcdf_fortv2_c_interfaces.mod
-# netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.$(OBJEXT) netcdf_nc_interfaces.mod
-# endif BUILD_V2
-
-# # If netCDF-4 is being build, build the netCDF-4 F77 API mod files.
-# if USE_NETCDF4
-# MODFILES += netcdf4_nc_interfaces.mod netcdf4_nf_interfaces.mod	\
-# netcdf4_f03.mod
-# netcdf4_nc_interfaces.mod: module_netcdf4_nc_interfaces.$(OBJEXT) netcdf_nc_interfaces.mod
-# netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.$(OBJEXT)
-# netcdf4_f03.mod: module_netcdf4_f03.$(OBJEXT)
-# endif USE_NETCDF4
 
 # The netcdf.inc file is built on the user machine, and installed as
 # a header.

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -33,30 +33,36 @@ noinst_LTLIBRARIES = libtypeSizes.la libnetcdf_nc_data.la	\
 libnetcdf_nf_data.la libnetcdf_nc_interfaces.la			\
 libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
 
+# These are the ource for the F77 API.
+libnetcdff_la_SOURCES = nf_attio.F90 nf_control.F90 nf_dim.f90		\
+nf_misc.f90 nf_genatt.f90 nf_geninq.f90 nf_genvar.f90 nf_vario.F90	\
+nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90
+
 # Different source for the netcdf.mod is used for netcdf classic
 # vs. netcdf4.
 if USE_NETCDF4
 libnetcdfm_la_SOURCES = netcdf4.f90
-netcdf4.$(OBJECT): typeSizes.mod
+netcdf4.$(OBJECT): typesizes.mod
 netcdf.mod: netcdf4.$(OBJEXT)
 EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES)
 else # classic-only build
 libnetcdfm_la_SOURCES = netcdf.f90
-netcdf.$(OBJECT): typeSizes.mod
+netcdf.$(OBJECT): typesizes.mod
 netcdf.mod: netcdf.$(OBJEXT)
 EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES) $(NETCDF4_CODES)
+libnetcdff_la_SOURCES += netcdf3_file.f90
 endif # USE_NETCDF4
 
 # Each convenience library depends on its source.
 libtypeSizes_la_SOURCES = typeSizes.f90
-libnetcdf_nc_data_la_SOURCES = module_netcdf_nc_data.f90
-libnetcdf_nf_data_la_SOURCES = module_netcdf_nf_data.f90
+libnetcdf_nc_data_la_SOURCES = module_netcdf_nc_data.F90
+libnetcdf_nf_data_la_SOURCES = module_netcdf_nf_data.F90
 libnetcdf_nc_interfaces_la_SOURCES = module_netcdf_nc_interfaces.f90
-libnetcdf_nf_interfaces_la_SOURCES = module_netcdf_nf_interfaces.f90
+libnetcdf_nf_interfaces_la_SOURCES = module_netcdf_nf_interfaces.F90
 libnetcdf_f03_la_SOURCES = module_netcdf_f03.f90
 
 # Each mod file depends on the .o file.
-typeSizes.mod: typeSizes.$(OBJEXT)
+typesizes.mod: typeSizes.$(OBJEXT)
 netcdf_nc_data.mod: module_netcdf_nc_data.$(OBJEXT)
 netcdf_nf_data.mod: module_netcdf_nf_data.$(OBJEXT)
 netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.$(OBJEXT)
@@ -71,18 +77,13 @@ module_netcdf_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod
 
 # Mod files are built and then installed as headers. Order is
 # significant in this list of modfiles.
-MODFILES = typeSizes.mod netcdf_nc_data.mod netcdf_nf_data.mod	\
+MODFILES = typesizes.mod netcdf_nc_data.mod netcdf_nf_data.mod	\
 netcdf_nc_interfaces.mod netcdf_nf_interfaces.mod
 
 # Add our convenience libraries to the netCDF fortran library.
 libnetcdff_la_LIBADD = libtypeSizes.la libnetcdf_nc_data.la	\
 libnetcdf_nf_data.la libnetcdf_nc_interfaces.la			\
 libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
-
-# These are the ource for the F77 API.
-libnetcdff_la_SOURCES = nf_attio.F90 nf_control.F90 nf_dim.f90		\
-nf_misc.f90 nf_genatt.f90 nf_geninq.f90 nf_genvar.f90 nf_vario.F90	\
-nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90
 
 # Add the V2 F77 API.
 if BUILD_V2
@@ -112,7 +113,7 @@ libnetcdf4_nf_interfaces.la libnetcdf4_f03.la
 
 # Each convenience library depends on its source.
 libnetcdf4_nc_interfaces_la_SOURCES = module_netcdf4_nc_interfaces.f90
-libnetcdf4_nf_interfaces_la_SOURCES = module_netcdf4_nf_interfaces.f90
+libnetcdf4_nf_interfaces_la_SOURCES = module_netcdf4_nf_interfaces.F90
 libnetcdf4_f03_la_SOURCES = module_netcdf4_f03.f90
 
 # Each mod file depends on the .o file.
@@ -135,11 +136,14 @@ libnetcdf4_nf_interfaces.la libnetcdf4_f03.la
 
 endif # USE_NETCDF4
 
+# This must come last in the list of MODFILES.
 MODFILES += netcdf.mod
 
-# Mod files are installed as headers, and are built sources.
-include_HEADERS = $(MODFILES)
+# Mod files are build sources.
 BUILT_SOURCES = $(MODFILES)
+
+# Mod files are installed as headers, but not distrubuted.
+nodist_include_HEADERS = $(MODFILES)
 
 # if USE_NETCDF4
 # NETCDF_O = netcdf4.$(OBJEXT)
@@ -222,7 +226,7 @@ BUILT_SOURCES = $(MODFILES)
 # The netcdf.inc file is built on the user machine, and installed as
 # a header.
 BUILT_SOURCES += netcdf.inc
-include_HEADERS += netcdf.inc
+nodist_include_HEADERS += netcdf.inc
 
 # Build netcdf.inc file from netcdf2, netcdf3 and netcdf4 files
 netcdf.inc: netcdf2.inc netcdf3.inc netcdf4.inc

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -245,8 +245,7 @@ if USE_LOGGING
 	echo '      external nf_set_log_level' >> netcdf.inc
 endif
 
-# EXTRA_DIST = $(COMMON_CODES) $(NETCDF4_CODES) CMakeLists.txt	\
-# netcdf2.inc netcdf3.inc netcdf4.inc
-EXTRA_DIST = CMakeLists.txt netcdf2.inc netcdf3.inc netcdf4.inc
+EXTRA_DIST = $(COMMON_CODES) $(NETCDF4_CODES) CMakeLists.txt	\
+netcdf2.inc netcdf3.inc netcdf4.inc
 
 CLEANFILES = *.mod netcdf.inc

--- a/fortran/netcdf.f90
+++ b/fortran/netcdf.f90
@@ -34,7 +34,7 @@
 !     length of the argument character string. 
 !
  module netcdf
-  use typeSizes, only: OneByteInt, TwoByteInt, FourByteInt, EightByteInt, &
+  use typesizes, only: OneByteInt, TwoByteInt, FourByteInt, EightByteInt, &
                        FourByteReal, EightByteReal
   implicit none
   private

--- a/fortran/netcdf4.f90
+++ b/fortran/netcdf4.f90
@@ -37,7 +37,7 @@
 ! Hartnett in 2006 to support the netCDF-4 API.
 !
  module netcdf
-  use typeSizes, only: OneByteInt, TwoByteInt, FourByteInt, EightByteInt, &
+  use typesizes, only: OneByteInt, TwoByteInt, FourByteInt, EightByteInt, &
                        FourByteReal, EightByteReal
   implicit none
   private

--- a/fortran/typeSizes.f90
+++ b/fortran/typeSizes.f90
@@ -27,7 +27,7 @@
 !   Fortran 90 doesn't allow one to check the number of bytes in a real variable;
 !     we check only that four byte and eight byte reals have different kind parameters. 
 !
-module typeSizes
+module typesizes
   implicit none
   public
   integer, parameter ::   OneByteInt = selected_int_kind(2), &


### PR DESCRIPTION
Fixes #177. 

In this PR I fix mod file dependency tacking.

I did this for the tests.mod file when re-doing the test directories. In this PR I do it for all the mod files in the fortran directory.

To reduce future confusion, I have renamed the (internal-only) mod file typeSizes to typesizes, matching the case of all the other mod files, and the case that gfortran and other fortran compilers want us to use for module names. This change will have no effect on user code.

With this PR, the .NOTPARALLEL directive is removed, and parallel (make -j) builds now work in all directories, demonstrating that all dependencies are being properly tracked.