### PR TITLE
Get filter test to work with Fortran

### DIFF
--- a/nf_test4/CMakeLists.txt
+++ b/nf_test4/CMakeLists.txt
@@ -47,9 +47,10 @@ if (USE_NETCDF4)
   ENDIF (TEST_PARALLEL)
 
   IF(ENABLE_FILTER_TEST)
-    LIST(APPEND check_PROGRAMS ftst_filter)
-    LIST(APPEND CLEANFILES ftst_filter.nc)
-    SET(ftst_filter_SOURCES ftst_filter.F)
+    SET(check_PROGRAMS ${check_PROGRAMS} ftst_filter)
+    SET(SCRIPT_TESTS ${SCRIPT_TESTS} run_tst_filter)
+    # Add executables
+    build_bin_test(ftst_filter ".F")
   ENDIF(ENABLE_FILTER_TEST)
 
 endif(USE_NETCDF4)

--- a/nf_test4/Makefile.am
+++ b/nf_test4/Makefile.am
@@ -53,8 +53,8 @@ endif # TEST_PARALLEL
 # Test filters.
 if TEST_FILTERS
 check_PROGRAMS += ftst_filter
-TESTS += ftst_filter
 ftst_filter_SOURCES = ftst_filter.F
+TESTS += run_tst_filter.sh
 endif
 
 # If sed is present, generate these tests at build time. They are the

--- a/nf_test4/ftst_filter.F
+++ b/nf_test4/ftst_filter.F
@@ -54,62 +54,62 @@ C     Create some pretend data.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_CLOBBER+NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define the dimensions.
       retval = nf_def_dim(ncid, "x", NX, x_dimid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_dim(ncid, "y", NY, y_dimid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define the variable. 
       dimids(1) = y_dimid
       dimids(2) = x_dimid
       retval = nf_def_var(ncid, "data", NF_INT64, NDIMS, dimids, varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Turn on chunking.
       chunks(1) = NY
       chunks(2) = NX
       retval = nf_def_var_chunking(ncid, varid, 0, chunks)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Set bzip filter on variable
       params(1) = 9
       retval = nf_def_var_filter(ncid, varid, 307, 1, params)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       retval = nf_enddef(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Write the pretend data to the file.
       retval = nf_put_var_int(ncid, varid, data_out)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file and check again.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Find our variable.
       retval = nf_inq_varid(ncid, "data", varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (varid .ne. 1) stop 2
 
 C     Check the filter
       params(1) = -1
       retval = nf_inq_var_filter(ncid, varid, filterid, nparams, params)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (filterid .ne. 307) stop 2
       if (nparams .ne. 1) stop 2
       if (params(1) .ne. 9) stop 2
 
 C     Read the data and check it.
       retval = nf_get_var_int(ncid, varid, data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, NX
          do y = 1, NY
             if (data_in(y, x) .ne. data_out(y, x)) stop 2
@@ -118,7 +118,7 @@ C     Read the data and check it.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/run_tst_filter.sh
+++ b/nf_test4/run_tst_filter.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Assume that netcdf-c installed bzip2 plugin
+PLUGINDIR=`../nf-config --prefix`
+export HDF5_PLUGIN_PATH="${PLUGINDIR}/lib"
+./ftst_filter
+
+


### PR DESCRIPTION
re: https://github.com/Unidata/netcdf-fortran/issues/169

This required a change both to netcdf-c and to netcdf-fortran.
For netcdf-c, see PR https://github.com/Unidata/netcdf-c/pull/1387

The fortran fix required creating a shell script: nf_test4/run_tst_filter.sh.
This script ensures that HDF5_PLUGIN_DIR is set to nf-config --prefix.
This assumes that you are using the version of netcdf-c where the bzip2
plugin is installed in the --prefix/lib dir as part of the netcdf-c
library install. This may not work correctly for Windows or OSX.