### PR TITLE
duplicated module_netcdf4_nc_interfaces.$(OBJEXT)

### DIFF
--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -124,7 +124,6 @@ netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.$(OBJEXT)
 netcdf4_f03.mod: module_netcdf4_f03.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-module_netcdf4_nc_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
 module_netcdf4_nf_interfaces.$(OBJEXT): netcdf4_nc_interfaces.mod
 module_netcdf4_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod netcdf4_nf_interfaces.mod
 


### PR DESCRIPTION
Fix error below when running autoreconf.
fortran/Makefile.am:127: warning: module_netcdf4_nc_interfaces.$(OBJEXT) was already defined in condition TRUE, which includes condition USE_NETCDF4 ...
fortran/Makefile.am:81: ... 'module_netcdf4_nc_interfaces.$(OBJEXT)' previously defined here