### PR TITLE
Use of "stop retval" is not portable

### DIFF
--- a/nf_test4/f03tst_open_mem.F
+++ b/nf_test4/f03tst_open_mem.F
@@ -67,17 +67,17 @@ C     Set up var names.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a dimension.
       retval = nf_def_dim(ncid, dim_name, DIM_LEN, dimids(1))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a few integer variables.
       do x = 1, NVARS      
          retval = nf_def_var(ncid, var_name(x), NF_INT, NDIMS, dimids,
      $        varid(x))
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
       end do
 
 C     Set no fill mode for the second variable.
@@ -94,7 +94,7 @@ c      if (retval .ne. 0) stop 2
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 C
 C *****   TESTING OF nf_open_mem ******
 C
@@ -138,7 +138,7 @@ C then call nf_open_mem in NF_DISKLESS mode
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       If (ALLOCATED(memfile)) DEALLOCATE(memfile)
       print *,'*** SUCCESS!'
@@ -178,18 +178,18 @@ C     Values that are read in, to check the file.
 C     Check it out.
       retval = nf_inq(ncid, ndims_in, nvars_in, ngatts_in,
      $     unlimdimid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ndims_in .ne. 1 .or. nvars_in .ne. NVARS .or. ngatts_in .ne. 0
      $     .or. unlimdimid_in .ne. -1) stop 5
 
 C     Get the varids and the dimid.
       do x = 1, NVARS      
          retval = nf_inq_varid(ncid, var_name(x), varid_in(x))
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
          if (varid_in(x) .ne. x) stop 6
       end do
       retval = nf_inq_dimid(ncid, dim_name, dimid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (dimid_in .ne. 1) stop 7
 
 C     These things are the same for all three variables, except
@@ -197,7 +197,7 @@ C     natts_in..
       do x = 1, NVARS      
          retval = nf_inq_var(ncid, varid_in(x), var_name_in, xtype_in,
      $        ndims_in, dimids_in, natts_in)
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
          if (ndims_in .ne. 1 .or. xtype_in .ne. NF_INT .or. dimids_in(1)
      $        .ne. dimid_in) stop 8
          if (x .eq. 3 .and. natts_in .ne. 1) stop 9
@@ -209,39 +209,39 @@ C     no_fill should be off, and fill_value should be the default fill
 C     value for this type.
       retval = nf_inq_var_fill(ncid, varid_in(1), no_fill_in,
      $     fill_value_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (no_fill_in .ne. 0 .or. fill_value_in .ne. nf_fill_int) stop 11
 
 C     Check that no_fill mode is on for the second variable.
       retval = nf_inq_var_fill(ncid, varid_in(2), no_fill_in,
      $     fill_value_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (no_fill_in .ne. 1 .or. fill_value_in .ne. nf_fill_int) stop 12
 
 C     Check that a non-default fill value is in use for the third variable.
       retval = nf_inq_var_fill(ncid, varid_in(3), no_fill_in,
      $     fill_value_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (no_fill_in .ne. 0 .or. fill_value_in .ne. MY_FILL_VALUE) stop
      $     2
 
 C     Get the data in var1. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(1), int_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, DIM_LEN
          if (int_data_in(x) .ne. nf_fill_int) stop 13
       end do
 
 C     Get the data in var2. What will it be?
       retval = nf_get_var_int(ncid, varid_in(2), int_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 C$$$      do x = 1, DIM_LEN
 C$$$         print *, int_data_in(x)
 C$$$      end do
 
 C     Get the data in var3. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(3), int_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, DIM_LEN
 C         print *, int_data_in(x)
          if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14

--- a/nf_test4/ftst_groups.F
+++ b/nf_test4/ftst_groups.F
@@ -41,112 +41,112 @@ C     Error handling.
 
 C     Create the netCDF file.
       retval = nf_create(file_name, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a group and a subgroup.
       retval = nf_def_grp(ncid, group_name, grpid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_grp(grpid, sub_group_name, sub_grpid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a two dims and two vars.
       retval = nf_def_dim(sub_grpid, dim1_name, 0, dimids(1))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_dim(sub_grpid, dim2_name, 0, dimids(2))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_var(sub_grpid, var1_name, NF_UINT64, 2, dimids, 
      &     varids(1))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_var(sub_grpid, var2_name, NF_UINT64, 2, dimids, 
      &     varids(2))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file.
       retval = nf_open(file_name, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       
 C     Check the name of the root group.
       retval = nf_inq_grpname(ncid, name_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:1) .ne. '/') stop 2
 
 C     Check the full name of the root group (also "/").
       retval = nf_inq_grpname_full(ncid, full_name_len, name_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (full_name_len .ne. 1 .or. name_in(1:1) .ne. '/') stop 2
 
 C     What groups are there from the root group?
       retval = nf_inq_grps(ncid, ngroups_in, grpids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ngroups_in .ne. 1) stop 2
 
 C     Check the name of this group.
       retval = nf_inq_grpname(grpids(1), name_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(group_name)) .ne. group_name) stop 2
 
 C     Check the length of the full name.
       retval = nf_inq_grpname_len(grpids(1), full_name_len)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (full_name_len .ne. len(group_name) + 1) stop 2
 
 C     Check the full name.
       retval = nf_inq_grpname_full(grpids(1), full_name_len, name_in2)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in2(1:1) .ne. '/' .or. 
      &     name_in2(2:len(group_name)+1) .ne. group_name .or.
      &     full_name_len .ne. len(group_name) + 1) stop 2
 
 C     Check getting the grpid by full name
       retval = nf_inq_grp_full_ncid(ncid, name_in, grpid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (grpid_in .ne. grpids(1)) stop 2
 
 C     Check the parent ncid.
       retval = nf_inq_grp_parent(grpids(1), grpid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (grpid_in .ne. ncid) stop 2
 
 C     Check getting the group by name
       retval = nf_inq_ncid(ncid, group_name, grpid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (grpid_in .ne. grpids(1)) stop 2
 
 C     Check getting the group by name
       retval = nf_inq_ncid(ncid, group_name, grpid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (grpid_in .ne. grpids(1)) stop 2
 
 C     Get the sub group id, using its name.
       retval = nf_inq_ncid(grpid_in, sub_group_name, subgrp_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Check varids in subgroup.
       retval = nf_inq_varids(subgrp_in, nvars, varids_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (nvars .ne. 2 .or. varids_in(1) .ne. varids(1) .or.
      &     varids_in(2) .ne. varids(2)) stop 2
 
 C     Check dimids in subgroup.
       retval = nf_inq_dimids(subgrp_in, ndims, dimids_in, 0)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ndims .ne. 2 .or. dimids_in(1) .ne. dimids(1) .or.
      &     dimids_in(2) .ne. dimids(2)) stop 2
 
 C     Check dimids including parents (will get same answers, since there
 C     are no dims in parent group.
       retval = nf_inq_dimids(subgrp_in, ndims, dimids_in, 1)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ndims .ne. 2 .or. dimids_in(1) .ne. dimids(1) .or.
      &     dimids_in(2) .ne. dimids(2)) stop 2
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_types.F
+++ b/nf_test4/ftst_types.F
@@ -55,26 +55,26 @@ C     Create some pretend data.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define the dimensions.
       retval = nf_def_dim(ncid, "x", NX, x_dimid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_dim(ncid, "y", NY, y_dimid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define a compound type.
       retval = nf_def_compound(ncid, WIND_T_SIZE, type_name, 
      &     wind_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_insert_compound(ncid, wind_typeid, u_name, 0, NF_INT)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_insert_compound(ncid, wind_typeid, v_name, 4, NF_INT)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Check out my new type.
       retval = nf_inq_typeids(ncid, ntypes, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ntypes .ne. 1) stop 2
       if (typeids(1) .ne. wind_typeid) stop 2
 
@@ -82,29 +82,29 @@ C     Define the variable.
       dimids(2) = x_dimid
       dimids(1) = y_dimid
       retval = nf_def_var(ncid, "data", NF_INT, NDIMS, dimids, varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Write the pretend data to the file.
       retval = nf_put_var_int(ncid, varid, data_out)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file and check again.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Find the type.
       retval = nf_inq_typeids(ncid, ntypes, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ntypes .ne. 1 .or. typeids(1) .ne. wind_typeid) stop 2
       
 C     Check the type.
       retval = nf_inq_user_type(ncid, typeids(1), name_in, size_in, 
      &     base_type_in, nfields_in, class_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(type_name)) .ne. type_name .or. 
      &     size_in .ne. WIND_T_SIZE .or. nfields_in .ne. 2 .or.
      &     class_in .ne. NF_COMPOUND) stop 2
@@ -112,58 +112,58 @@ C     Check the type.
 C     Check it differently.
       retval = nf_inq_compound(ncid, typeids(1), name_in, size_in, 
      &     nfields_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(type_name)) .ne. type_name .or. 
      &     size_in .ne. WIND_T_SIZE .or. nfields_in .ne. 2) stop 2
 
 C     Check it one piece at a time.
       retval = nf_inq_compound_nfields(ncid, typeids(1), nfields_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (nfields_in .ne. 2) stop 2
       retval = nf_inq_compound_size(ncid, typeids(1), size_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (size_in .ne. WIND_T_SIZE) stop 2
       retval = nf_inq_compound_name(ncid, typeids(1), name_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(type_name)) .ne. type_name) stop 2
 
 C     Check the first field of the compound type.
       retval = nf_inq_compound_field(ncid, typeids(1), 1, name_in, 
      &     offset_in, field_typeid_in, ndims_in, dim_sizes_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(u_name)) .ne. u_name .or. offset_in .ne. 0 .or.
      &     field_typeid_in .ne. NF_INT .or. ndims_in .ne. 0) stop 2
       retval = nf_inq_compound_fieldname(ncid, typeids(1), 1, name_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(u_name)) .ne. u_name) stop 2
       retval = nf_inq_compound_fieldoffset(ncid, typeids(1), 1, 
      &     offset_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (offset_in .ne. 0) stop 2
       retval = nf_inq_compound_fieldtype(ncid, typeids(1), 1, 
      &     field_typeid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (field_typeid_in .ne. NF_INT) stop 2
       retval = nf_inq_compound_fieldndims(ncid, typeids(1), 1, 
      &     ndims_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ndims_in .ne. 0) stop 2
       
 C     Check the second field of the compound type.
       retval = nf_inq_compound_field(ncid, typeids(1), 2, name_in, 
      &     offset_in, field_typeid_in, ndims_in, dim_sizes_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(v_name)) .ne. v_name .or. offset_in .ne. 4 .or.
      &     field_typeid_in .ne. NF_INT .or. ndims_in .ne. 0) stop 2
       
 C     Find our variable.
       retval = nf_inq_varid(ncid, "data", varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (varid .ne. 1) stop 2
 
 C     Read the data and check it.
       retval = nf_get_var_int(ncid, varid, data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, NX
          do y = 1, NY
             if (data_in(y, x) .ne. data_out(y, x)) stop 2
@@ -172,7 +172,7 @@ C     Read the data and check it.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_types2.F
+++ b/nf_test4/ftst_types2.F
@@ -45,37 +45,37 @@ C     Loop indexes, and error handling.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define a compound type.
       retval = nf_def_compound(ncid, cmp_size, type_name, 
      &     cmp_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Include an array.
       dim_sizes(1) = NX
       dim_sizes(2) = NY
       retval = nf_insert_array_compound(ncid, cmp_typeid, ary_name, 0, 
      &     NF_INT, NDIMS, dim_sizes)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file and check again.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Find the type.
       retval = nf_inq_typeids(ncid, ntypes, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ntypes .ne. 1 .or. typeids(1) .ne. cmp_typeid) stop 2
       
 C     Check the type.
       retval = nf_inq_user_type(ncid, typeids(1), name_in, size_in, 
      &     base_type_in, nfields_in, class_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(type_name)) .ne. type_name .or. 
      &     size_in .ne. cmp_size .or. nfields_in .ne. 1 .or. 
      &     class_in .ne. NF_COMPOUND) stop 2
@@ -83,7 +83,7 @@ C     Check the type.
 C     Check the first field of the compound type.
       retval = nf_inq_compound_field(ncid, typeids(1), 1, name_in, 
      &     offset_in, field_typeid_in, ndims_in, dim_sizes_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(ary_name)) .ne. ary_name .or. 
      &     offset_in .ne. 0 .or. field_typeid_in .ne. NF_INT .or. 
      &     ndims_in .ne. NDIMS .or. 
@@ -92,7 +92,7 @@ C     Check the first field of the compound type.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_types3.F
+++ b/nf_test4/ftst_types3.F
@@ -52,41 +52,41 @@ C     Loop indexes, and error handling.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a group and a subgroup.
       retval = nf_def_grp(ncid, group_name, grpid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_grp(grpid, sub_group_name, sub_grpid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define a compound type in the root group.
       retval = nf_def_compound(ncid, cmp_size, type_name, 
      &     cmp_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Include a float.
       retval = nf_insert_compound(ncid, cmp_typeid, field_name, 0, 
      &     NF_FLOAT)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file and check again.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Find the type.
       retval = nf_inq_typeids(ncid, ntypes, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ntypes .ne. 1 .or. typeids(1) .ne. cmp_typeid) stop 2
       
 C     Check the type.
       retval = nf_inq_user_type(ncid, typeids(1), name_in, size_in, 
      &     base_type_in, nfields_in, class_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(type_name)) .ne. type_name .or. 
      &     size_in .ne. cmp_size .or. nfields_in .ne. 1 .or. 
      &     class_in .ne. NF_COMPOUND) stop 31
@@ -94,19 +94,19 @@ C     Check the type.
 C     Check the first field of the compound type.
       retval = nf_inq_compound_field(ncid, typeids(1), 1, name_in, 
      &     offset_in, field_typeid_in, ndims_in, dim_sizes_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(field_name)) .ne. field_name .or. 
      &     offset_in .ne. 0 .or. field_typeid_in .ne. NF_FLOAT .or. 
      &     ndims_in .ne. 0) stop 19
 
 C     Go to a child group and find the id of our type.
       retval = nf_inq_grp_ncid(ncid, group_name, sub_grpid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_inq_typeid(sub_grpid, type_name, typeid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_inq_user_type(sub_grpid, typeid_in, name_in, size_in, 
      &     base_type_in, nfields_in, class_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (name_in(1:len(type_name)) .ne. type_name .or. 
      &     size_in .ne. cmp_size .or. nfields_in .ne. 1 .or. 
      &     class_in .ne. NF_COMPOUND) stop 22
@@ -115,7 +115,7 @@ C     Go to a child group and find the id of our type.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_vars.F
+++ b/nf_test4/ftst_vars.F
@@ -56,109 +56,109 @@ C     Create some pretend data.
 C     Change the cache size for the files created/opened in this program.
       retval = nf_set_chunk_cache(CACHE_SIZE, CACHE_NELEMS, 
      &     CACHE_PREEMPTION)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Check chunk cache sizes.
       retval = nf_get_chunk_cache(cache_size_in, cache_nelems_in, 
      &     cache_preemption_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (cache_size_in .ne. CACHE_SIZE .or. 
      &     cache_nelems_in .ne. CACHE_NELEMS .or. 
      &     cache_preemption_in .ne. CACHE_PREEMPTION) stop 4
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define the dimensions.
       retval = nf_def_dim(ncid, "x", NX, x_dimid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_dim(ncid, "y", NY, y_dimid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define the variable. 
       dimids(1) = y_dimid
       dimids(2) = x_dimid
       retval = nf_def_var(ncid, "data", NF_INT64, NDIMS, dimids, varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Turn on chunking.
       chunks(1) = NY
       chunks(2) = NX
       retval = nf_def_var_chunking(ncid, varid, 0, chunks)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Set variable to big-endian (default is whatever is native to
 C     writing machine).
       retval = nf_def_var_endian(ncid, varid, NF_ENDIAN_BIG)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Turn on deflate, fletcher32.
       retval = nf_def_var_deflate(ncid, varid, 0, 1, 4)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_var_fletcher32(ncid, varid, NF_FLETCHER32)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Is everything set that is supposed to be?
       retval = nf_inq_var_deflate(ncid, varid, shuffle, deflate, 
      +     deflate_level)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (shuffle .ne. 0 .or. deflate .ne. 1 .or. 
      +     deflate_level .ne. 4) stop 2
       retval = nf_inq_var_fletcher32(ncid, varid, checksum)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (checksum .ne. NF_FLETCHER32) stop 2
       retval = nf_inq_var_chunking(ncid, varid, contiguous, chunks_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (contiguous .ne. 0) stop 2
       if (chunks(1) .ne. chunks_in(1) .or.
      +     chunks(2) .ne. chunks_in(2)) stop 2
       retval = nf_inq_var_endian(ncid, varid, endianness)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (endianness .ne. NF_ENDIAN_BIG) stop 2
 
 C     Since this is a classic model file, we must call enddef
       retval = nf_enddef(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Write the pretend data to the file.
       retval = nf_put_var_int(ncid, varid, data_out)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file and check again.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Find our variable.
       retval = nf_inq_varid(ncid, "data", varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (varid .ne. 1) stop 2
 
 C     Check the deflate, fletcher32, chunking, and endianness.
       retval = nf_inq_var_deflate(ncid, varid, shuffle, deflate, 
      +     deflate_level)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (shuffle .ne. 0 .or. deflate .ne. 1 .or. 
      +     deflate_level .ne. 4) stop 2
       retval = nf_inq_var_fletcher32(ncid, varid, checksum)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (checksum .ne. NF_FLETCHER32) stop 2
       retval = nf_inq_var_chunking(ncid, varid, contiguous, chunks_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (contiguous .ne. 0) stop 2
       if (chunks(1) .ne. chunks_in(1) .or.
      +     chunks(2) .ne. chunks_in(2)) stop 2
       retval = nf_inq_var_endian(ncid, varid, endianness)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (endianness .ne. NF_ENDIAN_BIG) stop 2
 
 C     Read the data and check it.
       retval = nf_get_var_int(ncid, varid, data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, NX
          do y = 1, NY
             if (data_in(y, x) .ne. data_out(y, x)) stop 2
@@ -167,7 +167,7 @@ C     Read the data and check it.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_vars2.F
+++ b/nf_test4/ftst_vars2.F
@@ -59,15 +59,15 @@ C     Create some pretend data.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Define the dimensions.
       retval = nf_def_dim(ncid, "z", NZ, dimids(3))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_dim(ncid, "y", NY, dimids(2))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_def_dim(ncid, "x", NX, dimids(1))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     These are the types of vars that will be written.
       typeid(1) = NF_UBYTE
@@ -82,12 +82,12 @@ C     Define the variables.
  1001    format('var', I1)
          retval = nf_def_var(ncid, var_name, typeid(i), NDIMS, 
      &        dimids, varid(i))
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
 
 C        Set variable caches.
          retval = nf_set_var_chunk_cache(ncid, varid(i), CACHE_SIZE, 
      &        CACHE_NELEMS, CACHE_PREEMPTION)
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
       end do
 
 C     Check the per-variable cache to make sure it is what we think it
@@ -95,7 +95,7 @@ C     is.
       do i = 1, NTYPES
          retval = nf_get_var_chunk_cache(ncid, varid(i), cache_size_in, 
      &        cache_nelems_in, cache_preemption_in)
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
          if (cache_size_in .ne. CACHE_SIZE .or. cache_nelems_in .ne. 
      &        CACHE_NELEMS .or. cache_preemption .ne. CACHE_PREEMPTION)
      &        stop 8
@@ -105,21 +105,21 @@ C     is.
 C     Write the pretend data to the file.
       do i = 1, NTYPES
          retval = nf_put_var_int(ncid, varid(i), data_out)
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
       end do
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file and check again.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Read the data and check it.
       do i = 1, NTYPES
          retval = nf_get_var_int(ncid, varid(i), data_in)
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
          do x = 1, NX
             do y = 1, NY
                do z = 1, NZ
@@ -131,7 +131,7 @@ C     Read the data and check it.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_vars3.F
+++ b/nf_test4/ftst_vars3.F
@@ -67,58 +67,58 @@ C     Create some pretend data.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create the enum type.
       retval = nf_def_enum(ncid, NF_INT, enum_type_name, enum_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       one = 1
       zero = 0
       retval = nf_insert_enum(ncid, enum_typeid, zero_name, zero)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_insert_enum(ncid, enum_typeid, one_name, one)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create the opaque type.
       retval = nf_def_opaque(ncid, opaque_size, opaque_type_name, 
      &     opaque_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a dimension.
       retval = nf_def_dim(ncid, 'dim', 1, dimids(1))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create an opaque variable.
       retval = nf_def_var(ncid, 'var', opaque_typeid, 1, dimids, varid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Write the opaque scalar var. (Could also use nf_put_var).
       index(1) = 1
       retval = nf_put_var1(ncid, varid, index, opaque_data)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Attach an enum attribute to the variable.
       retval = nf_put_att(ncid, varid, 'att', enum_typeid, NX, 
      &     data_out)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Get the typeids of all user defined types.
       retval = nf_inq_typeids(ncid, num_types, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (num_types .ne. max_types) stop 2
 
 C     Use nf_inq_user_type to confirm this is an enum type.
       retval = nf_inq_user_type(ncid, typeids(1), type_name, type_size, 
      &     base_type, nfields, class)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(enum_type_name)) .ne. enum_type_name .or.
      &     type_size .ne. 4 .or. base_type .ne. NF_INT .or. 
      &     nfields .ne. 2 .or. class .ne. nf_enum) stop 2
@@ -127,33 +127,33 @@ C     Use nf_inq_enum and make sure we get the same answers as we did
 C     with nf_inq_user_type.
       retval = nf_inq_enum(ncid, typeids(1), type_name, base_type, 
      &     base_size, num_members)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(enum_type_name)) .ne. enum_type_name .or.
      &     base_type .ne. NF_INT .or. num_members .ne. 2) stop 2
 
 C     Check the members of the enum type.
       retval = nf_inq_enum_member(ncid, typeids(1), 1, member_name, 
      &     member_value)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (member_name(1:len(zero_name)) .ne. zero_name .or.
      &     member_value .ne. 0) stop 2
       retval = nf_inq_enum_member(ncid, typeids(1), 2, member_name, 
      &     member_value)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (member_name(1:len(one_name)) .ne. one_name .or.
      &     member_value .ne. 1) stop 2
       retval = nf_inq_enum_ident(ncid, typeids(1), 0, member_name)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (member_name(1:len(zero_name)) .ne. zero_name) stop 2
       retval = nf_inq_enum_ident(ncid, typeids(1), 1, member_name)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (member_name(1:len(one_name)) .ne. one_name) stop 2
 
 C     Use nf_inq_user_type to confirm that the second typeid is an
 C     opaque type.
       retval = nf_inq_user_type(ncid, typeids(2), type_name, type_size, 
      &     base_type, nfields, class)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(opaque_type_name)) .ne. opaque_type_name .or.
      &     type_size .ne. opaque_size .or. base_type .ne. 0 .or. 
      &     nfields .ne. 0 .or. class .ne. nf_opaque) stop 2
@@ -161,7 +161,7 @@ C     opaque type.
 C     Use nf_inq_opaque and make sure we get the same answers as we did
 C     with nf_inq_user_type.
       retval = nf_inq_opaque(ncid, typeids(2), type_name, base_size)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (base_size .ne. opaque_size .or. 
      &     type_name(1:len(opaque_type_name)) .ne. opaque_type_name) 
      &     stop 2
@@ -169,12 +169,12 @@ C     with nf_inq_user_type.
 C     Read the variable.
       index(1) = 1
       retval = nf_get_var1(ncid, varid, index, opaque_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (opaque_data_in .ne. opaque_data) stop 2
 
 C     Read the attribute.
       retval = nf_get_att(ncid, varid, 'att', data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Check the values.
       do x = 1, NX
@@ -183,7 +183,7 @@ C     Check the values.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_vars4.F
+++ b/nf_test4/ftst_vars4.F
@@ -51,40 +51,40 @@ C     Loop indexes, and error handling.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create the vlen type.
       retval = nf_def_vlen(ncid, vlen_type_name, nf_int, vlen_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Set up the vlen with this helper function, since F77 can't deal
 C     with pointers.
       retval = nf_put_vlen_element(ncid, vlen_typeid, vlen, 
      &     vlen_len, data1)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Write the vlen attribute.
       retval = nf_put_att(ncid, NF_GLOBAL, 'att1', vlen_typeid, 1, vlen)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Get the typeids of all user defined types.
       retval = nf_inq_typeids(ncid, num_types, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (num_types .ne. max_types) stop 2
 
 C     Use nf_inq_user_type to confirm this is an vlen type, with base
 C     type NF_INT.
       retval = nf_inq_user_type(ncid, typeids(1), type_name, type_size, 
      &     base_type, nfields, class)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(vlen_type_name)) .ne. vlen_type_name .or.
      &     base_type .ne. nf_int .or.
      &     nfields .ne. 0 .or. class .ne. nf_vlen) stop 2
@@ -93,18 +93,18 @@ C     Use nf_inq_vlen and make sure we get the same answers as we did
 C     with nf_inq_user_type.
       retval = nf_inq_vlen(ncid, typeids(1), type_name, base_size, 
      &     base_type)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(vlen_type_name)) .ne. vlen_type_name .or.
      &     base_type .ne. nf_int) stop 2
 
 C     Read the vlen attribute.
       retval = nf_get_att(ncid, NF_GLOBAL, 'att1', vlen_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Get the data from the vlen we just read.
       retval = nf_get_vlen_element(ncid, vlen_typeid, vlen_in, 
      &     vlen_len_in, data1_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (vlen_len_in .ne. vlen_len) stop 2
 
 C     Check the data
@@ -114,7 +114,7 @@ C     Check the data
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_vars5.F
+++ b/nf_test4/ftst_vars5.F
@@ -50,43 +50,43 @@ C     Prepare some data to write.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create the compound type.
       retval = nf_def_compound(ncid, 8, cmp_type_name, 
      &     cmp_typeid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Insert two integers.
       retval = nf_insert_compound(ncid, cmp_typeid, int1_name, 
      &     0, NF_INT)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       retval = nf_insert_compound(ncid, cmp_typeid, int2_name, 
      &     4, NF_INT)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Write the compound attribute.
       retval = nf_put_att(ncid, NF_GLOBAL, att_name, cmp_typeid, 
      &     1, data1)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Get the typeids of all user defined types.
       retval = nf_inq_typeids(ncid, num_types, typeids)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (num_types .ne. max_types) stop 2
 
 C     Use nf_inq_user_type to confirm this is an compound type
       retval = nf_inq_user_type(ncid, typeids(1), type_name, type_size, 
      &     base_type, nfields, class)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(cmp_type_name)) .ne. cmp_type_name .or.
      &     type_size .ne. 8 .or. base_type .ne. 0 .or.
      &     nfields .ne. 2 .or. class .ne. nf_compound) stop 2
@@ -95,14 +95,14 @@ C     Use nf_inq_compound and make sure we get the same answers as we did
 C     with nf_inq_user_type.
       retval = nf_inq_compound(ncid, typeids(1), type_name, type_size, 
      &     nfields)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (type_name(1:len(cmp_type_name)) .ne. cmp_type_name .or.
      &     base_type .ne. 0 .or. type_size .ne. 8 .or.
      &     nfields .ne. 2) stop 2
 
 C     Read the compound attribute.
       retval = nf_get_att(ncid, NF_GLOBAL, att_name, data1_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Check the data
       do x = 1, compound_len
@@ -111,7 +111,7 @@ C     Check the data
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end

--- a/nf_test4/ftst_vars6.F
+++ b/nf_test4/ftst_vars6.F
@@ -53,17 +53,17 @@ C     Set up var names.
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a dimension.
       retval = nf_def_dim(ncid, dim_name, DIM_LEN, dimids(1))
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Create a few integer variables.
       do x = 1, NVARS      
          retval = nf_def_var(ncid, var_name(x), NF_INT, NDIMS, dimids,
      $        varid(x))
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
       end do
 
 C     Set no fill mode for the second variable.
@@ -80,11 +80,11 @@ c      if (retval .ne. 0) stop 2
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Reopen the file.
       retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
 C     Check it out. 
       retval = check_file(ncid, var_name, dim_name)
@@ -92,7 +92,7 @@ C     Check it out.
 
 C     Close the file. 
       retval = nf_close(ncid)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 
       print *,'*** SUCCESS!'
       end
@@ -131,18 +131,18 @@ C     Values that are read in, to check the file.
 C     Check it out.
       retval = nf_inq(ncid, ndims_in, nvars_in, ngatts_in,
      $     unlimdimid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (ndims_in .ne. 1 .or. nvars_in .ne. NVARS .or. ngatts_in .ne. 0
      $     .or. unlimdimid_in .ne. -1) stop 5
 
 C     Get the varids and the dimid.
       do x = 1, NVARS      
          retval = nf_inq_varid(ncid, var_name(x), varid_in(x))
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
          if (varid_in(x) .ne. x) stop 6
       end do
       retval = nf_inq_dimid(ncid, dim_name, dimid_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (dimid_in .ne. 1) stop 7
 
 C     These things are the same for all three variables, except
@@ -150,7 +150,7 @@ C     natts_in..
       do x = 1, NVARS      
          retval = nf_inq_var(ncid, varid_in(x), var_name_in, xtype_in,
      $        ndims_in, dimids_in, natts_in)
-         if (retval .ne. nf_noerr) stop retval
+         if (retval .ne. nf_noerr) stop 1
          if (ndims_in .ne. 1 .or. xtype_in .ne. NF_INT .or. dimids_in(1)
      $        .ne. dimid_in) stop 8
          if (x .eq. 3 .and. natts_in .ne. 1) stop 9
@@ -162,39 +162,39 @@ C     no_fill should be off, and fill_value should be the default fill
 C     value for this type.
       retval = nf_inq_var_fill(ncid, varid_in(1), no_fill_in,
      $     fill_value_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (no_fill_in .ne. 0 .or. fill_value_in .ne. nf_fill_int) stop 11
 
 C     Check that no_fill mode is on for the second variable.
       retval = nf_inq_var_fill(ncid, varid_in(2), no_fill_in,
      $     fill_value_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (no_fill_in .ne. 1 .or. fill_value_in .ne. nf_fill_int) stop 12
 
 C     Check that a non-default fill value is in use for the third variable.
       retval = nf_inq_var_fill(ncid, varid_in(3), no_fill_in,
      $     fill_value_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       if (no_fill_in .ne. 0 .or. fill_value_in .ne. MY_FILL_VALUE) stop
      $     2
 
 C     Get the data in var1. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(1), int_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, DIM_LEN
          if (int_data_in(x) .ne. nf_fill_int) stop 13
       end do
 
 C     Get the data in var2. What will it be?
       retval = nf_get_var_int(ncid, varid_in(2), int_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
 C$$$      do x = 1, DIM_LEN
 C$$$         print *, int_data_in(x)
 C$$$      end do
 
 C     Get the data in var3. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(3), int_data_in)
-      if (retval .ne. nf_noerr) stop retval
+      if (retval .ne. nf_noerr) stop 1
       do x = 1, DIM_LEN
 C         print *, int_data_in(x)
          if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14


### PR DESCRIPTION
When using gfortran 4.4.7, I got compile error message below.
```
Making check in nf_test4
Fortran/netcdf-fortran/nf_test4/ftst_groups.F:44.72:
         if (retval .ne. nf_noerr) stop retval                          
                                                                        1
Error: Syntax error in STOP statement at (1)
```

Fortran stop statement: STOP [str] where str is a
string of no more that 5 digits or a character constant.