### PR TITLE
support nc_def_var_szip in Fortran APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,8 +90,13 @@ fi
 AC_MSG_RESULT([$nc_has_parallel4])
 
 # Starting with version 4.7.4, netcdf-c has function nc_def_var_szip().
-AC_SEARCH_LIBS([nc_def_var_szip], [netcdf], [nc_has_szip_write=yes], [nc_has_szip_write=no])
-AC_MSG_CHECKING([if netCDF was built with nc_def_var_szip()])
+AC_SEARCH_LIBS([nc_def_var_szip], [netcdf], [], [AC_MSG_ERROR([netcdf-c version 4.7.4 or greater is required])])
+AC_MSG_CHECKING([if netCDF was built with support for szip writes])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#include <netcdf_meta.h>
+#if !defined(NC_HAS_SZIP_WRITE)
+      choke me
+#endif]])], [nc_has_szip_write=yes], [nc_has_szip_write=no])
 AC_MSG_RESULT([$nc_has_szip_write])
 AM_CONDITIONAL(TEST_SZIP_WRITE, [test "x$nc_has_szip_write" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,7 @@ AC_MSG_RESULT([$nc_has_parallel4])
 AC_SEARCH_LIBS([nc_def_var_szip], [netcdf], [nc_has_szip_write=yes], [nc_has_szip_write=no])
 AC_MSG_CHECKING([if netCDF was built with nc_def_var_szip()])
 AC_MSG_RESULT([$nc_has_szip_write])
+AM_CONDITIONAL(TEST_SZIP_WRITE, [test "x$nc_has_szip_write" = xyes])
 
 # Find valgrind, if available, and add targets for it (ex:
 # check-valgrind).

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,11 @@ if test "x$nc_has_parallel4" = xyes; then
 fi
 AC_MSG_RESULT([$nc_has_parallel4])
 
+# Starting with version 4.7.4, netcdf-c has function nc_def_var_szip().
+AC_SEARCH_LIBS([nc_def_var_szip], [netcdf], [nc_has_szip_write=yes], [nc_has_szip_write=no])
+AC_MSG_CHECKING([if netCDF was built with nc_def_var_szip()])
+AC_MSG_RESULT([$nc_has_szip_write])
+
 # Find valgrind, if available, and add targets for it (ex:
 # check-valgrind).
 AX_VALGRIND_DFLT([sgcheck], [off])
@@ -495,6 +500,7 @@ AC_SUBST(HAS_F03,[$nc_build_f03])
 AC_SUBST(HAS_DAP,[$nc_has_dap])
 AC_SUBST(HAS_NC2,[$nc_build_v2])
 AC_SUBST(HAS_NC4,[$nc_build_v4])
+AC_SUBST(HAS_SZIP_WRITE,[$nc_has_szip_write])
 
 # Some files need to exist in build directories that do not correspond
 # to their source directory, or the test program makes an assumption

--- a/fortran/module_netcdf4_nf_interfaces.F90
+++ b/fortran/module_netcdf4_nf_interfaces.F90
@@ -522,6 +522,16 @@ Interface
 
  End Function nf_inq_var_deflate
 End Interface
+!-------------------------------- nf_def_var_szip --------------------------
+Interface
+ Function nf_def_var_szip( ncid, varid, options_mask, pixels_per_block) &
+                               RESULT (status)
+
+ Integer, Intent(IN) :: ncid, varid, options_mask, pixels_per_block
+ Integer             :: status
+
+ End Function nf_def_var_szip
+End Interface
 !-------------------------------- nf_inq_var_szip -----------------------------
 Interface
  Function nf_inq_var_szip(ncid, varid, options_mask, pixels_per_block) RESULT(status)

--- a/fortran/module_netcdf_nc_interfaces.f90
+++ b/fortran/module_netcdf_nc_interfaces.f90
@@ -2529,11 +2529,11 @@ End Interface
 
 !---------------------------------- nc_def_var_szip ---------------------------------
 Interface
- Function nc_def_var_szip(ncid, varid, level) BIND(C)
+ Function nc_def_var_szip(ncid, varid, options_mask, pixels_per_block) BIND(C)
 
  USE ISO_C_BINDING, ONLY: C_CHAR, C_INT
 
- Integer(C_INT), VALUE :: ncid, varid, level
+ Integer(C_INT), VALUE :: ncid, varid, options_mask, pixels_per_block
 
  Integer(C_INT) :: nc_def_var_szip
 

--- a/fortran/module_netcdf_nc_interfaces.f90
+++ b/fortran/module_netcdf_nc_interfaces.f90
@@ -2528,17 +2528,17 @@ Interface
 End Interface
 
 !---------------------------------- nc_def_var_szip ---------------------------------
-Interface
- Function nc_def_var_szip(ncid, varid, level) BIND(C)
+! Interface
+!  Function nc_def_var_szip(ncid, varid, level) BIND(C)
 
- USE ISO_C_BINDING, ONLY: C_CHAR, C_INT
+!  USE ISO_C_BINDING, ONLY: C_CHAR, C_INT
 
- Integer(C_INT), VALUE :: ncid, varid, level
+!  Integer(C_INT), VALUE :: ncid, varid, level
 
- Integer(C_INT) :: nc_def_var_szip
+!  Integer(C_INT) :: nc_def_var_szip
 
- End Function nc_def_var_szip
-End Interface
+!  End Function nc_def_var_szip
+! End Interface
 
 !---------------------------- Start of module procedures ---------------------
 CONTAINS

--- a/fortran/module_netcdf_nc_interfaces.f90
+++ b/fortran/module_netcdf_nc_interfaces.f90
@@ -2526,6 +2526,20 @@ Interface
 
  End Function nc_set_default_format
 End Interface
+
+!---------------------------------- nc_def_var_szip ---------------------------------
+Interface
+ Function nc_def_var_szip(ncid, varid, level) BIND(C)
+
+ USE ISO_C_BINDING, ONLY: C_CHAR, C_INT
+
+ Integer(C_INT), VALUE :: ncid, varid, level
+
+ Integer(C_INT) :: nc_def_var_szip
+
+ End Function nc_def_var_szip
+End Interface
+
 !---------------------------- Start of module procedures ---------------------
 CONTAINS
 

--- a/fortran/module_netcdf_nc_interfaces.f90
+++ b/fortran/module_netcdf_nc_interfaces.f90
@@ -2528,17 +2528,17 @@ Interface
 End Interface
 
 !---------------------------------- nc_def_var_szip ---------------------------------
-! Interface
-!  Function nc_def_var_szip(ncid, varid, level) BIND(C)
+Interface
+ Function nc_def_var_szip(ncid, varid, level) BIND(C)
 
-!  USE ISO_C_BINDING, ONLY: C_CHAR, C_INT
+ USE ISO_C_BINDING, ONLY: C_CHAR, C_INT
 
-!  Integer(C_INT), VALUE :: ncid, varid, level
+ Integer(C_INT), VALUE :: ncid, varid, level
 
-!  Integer(C_INT) :: nc_def_var_szip
+ Integer(C_INT) :: nc_def_var_szip
 
-!  End Function nc_def_var_szip
-! End Interface
+ End Function nc_def_var_szip
+End Interface
 
 !---------------------------- Start of module procedures ---------------------
 CONTAINS

--- a/fortran/netcdf4.inc
+++ b/fortran/netcdf4.inc
@@ -203,6 +203,12 @@
       integer nf_inq_var_deflate
       external nf_inq_var_deflate
 
+      integer nf_def_var_szip
+      external nf_def_var_szip
+
+      integer nf_inq_var_szip
+      external nf_inq_var_szip
+
       integer nf_def_var_fletcher32
       external nf_def_var_fletcher32
 

--- a/fortran/netcdf4_externals.f90
+++ b/fortran/netcdf4_externals.f90
@@ -1,6 +1,6 @@
 ! This is part of the netCDF-4 fortran 90 API.
 ! Copyright 2006, UCAR
-! $Id: netcdf4_externals.f90,v 1.21 2010/01/20 13:06:15 ed Exp $
+! Ed Hartnett
 
   ! Extra netCDF-4 functions
 
@@ -26,6 +26,6 @@
        nf_put_varm_int64, nf_put_var_int64, nf_get_var1_int64, &
        nf_get_vara_int64, nf_get_vars_int64, nf_get_varm_int64, &
        nf_get_var_int64, nf_get_chunk_cache, nf_set_chunk_cache, &
-       nf_inq_var_szip, nf_free_vlens, nf_free_string, &
+       nf_inq_var_szip, nf_def_var_szip, nf_free_vlens, nf_free_string, &
        nf_set_var_chunk_cache, nf_get_var_chunk_cache, nf_rename_grp, &
        nf_def_var_filter, nf_inq_var_filter

--- a/fortran/netcdf4_func.f90
+++ b/fortran/netcdf4_func.f90
@@ -521,6 +521,16 @@
     nf90_def_var_deflate = nf_def_var_deflate(ncid, varid, shuffle, deflate, deflate_level)
   end function nf90_def_var_deflate
   ! -----------
+  function nf90_def_var_szip(ncid, varid, options_mask, pixels_per_block)
+    integer, intent(in) :: ncid
+    integer, intent(in) :: varid
+    integer, intent(in) :: options_mask
+    integer, intent(in) :: pixels_per_block
+    integer :: nf90_def_var_szip
+
+    nf90_def_var_szip = nf_def_var_szip(ncid, varid, options_mask, pixels_per_block)
+  end function nf90_def_var_szip
+  ! -----------
   function nf90_def_var_fletcher32(ncid, varid, fletcher32)
     integer, intent(in) :: ncid
     integer, intent(in) :: varid
@@ -550,6 +560,16 @@
   
     nf90_inq_var_deflate = nf_inq_var_deflate(ncid, varid, shuffle, deflate, deflate_level)
   end function nf90_inq_var_deflate
+  ! -----------
+  function nf90_inq_var_szip(ncid, varid, options_mask, pixels_per_block)
+    integer, intent(in) :: ncid
+    integer, intent(in) :: varid
+    integer, intent(out) :: options_mask
+    integer, intent(out) :: pixels_per_block
+    integer :: nf90_inq_var_szip
+
+    nf90_inq_var_szip = nf_inq_var_szip(ncid, varid, options_mask, pixels_per_block)
+  end function nf90_inq_var_szip
   ! -----------
   function nf90_inq_var_fletcher32(ncid, varid, fletcher32)
     integer, intent(in) :: ncid

--- a/fortran/netcdf4_visibility.f90
+++ b/fortran/netcdf4_visibility.f90
@@ -1,6 +1,9 @@
-! This is part of the netCDF-4 fortran 90 API.
-! Copyright 2006, UCAR
-! $Id: netcdf4_visibility.f90,v 1.15 2009/09/28 17:53:00 ed Exp $
+! This is part of the netCDF-4 fortran 90 API. Copyright 2020, UCAR
+!
+! This file makes visible all the public functions added for
+! netCDF-4.
+!
+! Ed Hartnett, Dennis Heimbigner
   
 public :: nf90_create_par, nf90_open_par, nf90_var_par_access, &
      nf90_inq_ncid, nf90_inq_grps, nf90_inq_grp_ncid, nf90_inq_grp_full_ncid, nf90_inq_grpname, &
@@ -19,6 +22,5 @@ public :: nf90_create_par, nf90_open_par, nf90_var_par_access, &
      nf90_def_var_fill, nf90_inq_var_fill, &
      nf90_def_var_endian, nf90_inq_var_endian, nf90_inq_user_type, &
      nf90_put_att_any, nf90_get_att_any, nf90_get_var_any, nf90_put_var_any, &
-     nf90_rename_grp, nf90_def_var_filter, nf90_inq_var_filter
-     
-  
+     nf90_rename_grp, nf90_def_var_filter, nf90_inq_var_filter, &
+     nf90_def_var_szip, nf90_inq_var_szip

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -1521,22 +1521,22 @@
  End Function nf_inq_var_deflate
 
 !-------------------------------- nf_def_var_szip --------------------------
- Function nf_def_var_szip(ncid, varid, level) RESULT (status)
-! define variable deflation
- USE netcdf4_nc_interfaces
- Implicit NONE
- Integer, Intent(IN) :: ncid, varid, level
- Integer :: status
- Integer(C_INT) :: cncid, cvarid, clevel, cstatus
+!  Function nf_def_var_szip(ncid, varid, level) RESULT (status)
+! ! define variable deflation
+!  USE netcdf4_nc_interfaces
+!  Implicit NONE
+!  Integer, Intent(IN) :: ncid, varid, level
+!  Integer :: status
+!  Integer(C_INT) :: cncid, cvarid, clevel, cstatus
 
- cncid = ncid
- cvarid = varid-1
- clevel = level
+!  cncid = ncid
+!  cvarid = varid-1
+!  clevel = level
 
- cstatus = nc_def_var_szip(cncid, cvarid, clevel)
- status = cstatus
+!  cstatus = nc_def_var_szip(cncid, cvarid, clevel)
+!  status = cstatus
 
- End Function nf_def_var_szip
+!  End Function nf_def_var_szip
 !-------------------------------- nf_inq_var_szip -----------------------------
  Function nf_inq_var_szip(ncid, varid, options_mask, pixels_per_block) RESULT(status)
 

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -1520,6 +1520,23 @@
  
  End Function nf_inq_var_deflate
 
+!-------------------------------- nf_def_var_szip --------------------------
+ Function nf_def_var_szip(ncid, varid, level) RESULT (status)
+! define variable deflation
+ USE netcdf4_nc_interfaces
+ Implicit NONE
+ Integer, Intent(IN) :: ncid, varid, level
+ Integer :: status
+ Integer(C_INT) :: cncid, cvarid, clevel, cstatus
+
+ cncid = ncid
+ cvarid = varid-1
+ clevel = level
+
+ cstatus = nc_def_var_szip(cncid, cvarid, clevel)
+ status = cstatus
+
+ End Function nf_def_var_szip
 !-------------------------------- nf_inq_var_szip -----------------------------
  Function nf_inq_var_szip(ncid, varid, options_mask, pixels_per_block) RESULT(status)
 

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -1521,22 +1521,22 @@
  End Function nf_inq_var_deflate
 
 !-------------------------------- nf_def_var_szip --------------------------
-!  Function nf_def_var_szip(ncid, varid, level) RESULT (status)
-! ! define variable deflation
-!  USE netcdf4_nc_interfaces
-!  Implicit NONE
-!  Integer, Intent(IN) :: ncid, varid, level
-!  Integer :: status
-!  Integer(C_INT) :: cncid, cvarid, clevel, cstatus
+ Function nf_def_var_szip(ncid, varid, level) RESULT (status)
+! define variable deflation
+ USE netcdf4_nc_interfaces
+ Implicit NONE
+ Integer, Intent(IN) :: ncid, varid, level
+ Integer :: status
+ Integer(C_INT) :: cncid, cvarid, clevel, cstatus
 
-!  cncid = ncid
-!  cvarid = varid-1
-!  clevel = level
+ cncid = ncid
+ cvarid = varid-1
+ clevel = level
 
-!  cstatus = nc_def_var_szip(cncid, cvarid, clevel)
-!  status = cstatus
+ cstatus = nc_def_var_szip(cncid, cvarid, clevel)
+ status = cstatus
 
-!  End Function nf_def_var_szip
+ End Function nf_def_var_szip
 !-------------------------------- nf_inq_var_szip -----------------------------
  Function nf_inq_var_szip(ncid, varid, options_mask, pixels_per_block) RESULT(status)
 

--- a/fortran/nf_nc4.f90
+++ b/fortran/nf_nc4.f90
@@ -1521,19 +1521,21 @@
  End Function nf_inq_var_deflate
 
 !-------------------------------- nf_def_var_szip --------------------------
- Function nf_def_var_szip(ncid, varid, level) RESULT (status)
+ Function nf_def_var_szip(ncid, varid, options_mask, pixels_per_block) &
+      RESULT (status)
 ! define variable deflation
  USE netcdf4_nc_interfaces
  Implicit NONE
- Integer, Intent(IN) :: ncid, varid, level
+ Integer, Intent(IN) :: ncid, varid, options_mask, pixels_per_block
  Integer :: status
- Integer(C_INT) :: cncid, cvarid, clevel, cstatus
+ Integer(C_INT) :: cncid, cvarid, coptions_mask, cpixels_per_block, cstatus
 
  cncid = ncid
  cvarid = varid-1
- clevel = level
+ coptions_mask = options_mask
+ cpixels_per_block = pixels_per_block
 
- cstatus = nc_def_var_szip(cncid, cvarid, clevel)
+ cstatus = nc_def_var_szip(cncid, cvarid, coptions_mask, cpixels_per_block)
  status = cstatus
 
  End Function nf_def_var_szip

--- a/nf03_test4/Makefile.am
+++ b/nf03_test4/Makefile.am
@@ -61,6 +61,13 @@ f90tst_nc4_par_SOURCES = f90tst_nc4_par.F90
 f90tst_parallel_fill_SOURCES = f90tst_parallel_fill.f90
 endif # TEST_PARALLEL
 
+# Test szip if write capability is present in C library.
+if TEST_SZIP_WRITE
+check_PROGRAMS += f90tst_var_szip
+TESTS += f90tst_var_szip
+f90tst_var_szip_SOURCES = f90tst_var_szip.f90
+endif # TEST_SZIP_WRITE
+
 # If valgrind is present on this machine, this will enable
 # check-valgrind target, which runs all tests with valgrind.
 @VALGRIND_CHECK_RULES@

--- a/nf03_test4/f90tst_var_szip.f90
+++ b/nf03_test4/f90tst_var_szip.f90
@@ -1,0 +1,112 @@
+!     This is part of the netCDF package.
+!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
+!     See COPYRIGHT file for conditions of use.
+
+!     This program tests netCDF-4 variable functions from fortran.
+
+!     Ed Hartnett, 2009
+
+program f90tst_var_szip
+  use typeSizes
+  use netcdf
+  implicit none
+
+  ! This is the name of the data file we will create.
+  character (len = *), parameter :: FILE_NAME = "f90tst_var_szip.nc"
+
+  integer, parameter :: MAX_DIMS = 2
+  integer, parameter :: NX = 40, NY = 4096
+  integer :: data_out(NY, NX), data_in(NY, NX)
+
+  ! We need these ids and other gunk for netcdf.
+  integer :: ncid, varid, dimids(MAX_DIMS), chunksizes(MAX_DIMS)
+  integer :: x_dimid, y_dimid
+  integer :: mode_flag
+  integer :: nvars, ngatts, ndims, unlimdimid, file_format
+  integer :: x, y
+  integer, parameter :: CACHE_SIZE = 1000000
+  integer :: xtype_in, natts_in, dimids_in(MAX_DIMS), chunksizes_in(MAX_DIMS)
+  logical :: contiguous_in, shuffle_in, fletcher32_in
+  integer :: deflate_level_in, endianness_in
+  character (len = NF90_MAX_NAME) :: name_in
+
+
+  print *, ''
+  print *,'*** Testing definition of netCDF-4 vars from Fortran 90.'
+
+  ! Create some pretend data.
+  do x = 1, NX
+     do y = 1, NY
+        data_out(y, x) = (x - 1) * NY + (y - 1)
+     end do
+  end do
+
+  ! Create the netCDF file. 
+  mode_flag = IOR(nf90_netcdf4, nf90_classic_model) 
+  call handle_err(nf90_create(FILE_NAME, mode_flag, ncid, cache_size = CACHE_SIZE))
+
+  ! Define the dimensions.
+  call handle_err(nf90_def_dim(ncid, "x", NX, x_dimid))
+  call handle_err(nf90_def_dim(ncid, "y", NY, y_dimid))
+  dimids =  (/ y_dimid, x_dimid /)
+
+  ! Define the variable. 
+  chunksizes = (/ 256, 10 /)
+  call handle_err(nf90_def_var(ncid, 'data', NF90_INT, dimids, & 
+       varid, chunksizes = chunksizes, deflate_level = 4))
+
+  ! With classic model netCDF-4 file, enddef must be called.
+  call handle_err(nf90_enddef(ncid))
+
+  ! Write the pretend data to the file.
+  call handle_err(nf90_put_var(ncid, varid, data_out))
+
+  ! Close the file. 
+  call handle_err(nf90_close(ncid))
+
+  ! Reopen the file.
+  call handle_err(nf90_open(FILE_NAME, nf90_nowrite, ncid))
+  
+  ! Check some stuff out.
+  call handle_err(nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid, file_format))
+  if (ndims /= 2 .or. nvars /= 1 .or. ngatts /= 0 .or. unlimdimid /= -1 .or. &
+       file_format /= nf90_format_netcdf4_classic) stop 3
+
+  call handle_err(nf90_inquire_variable(ncid, varid, name_in, xtype_in, ndims, dimids_in, &
+       natts_in, contiguous_in, chunksizes_in, deflate_level_in, shuffle_in, fletcher32_in, &
+       endianness_in))
+  if (name_in .ne. 'data' .or. xtype_in .ne. NF90_INT .or. ndims .ne. MAX_DIMS .or. &
+       dimids_in(1) /= y_dimid .or. dimids_in(2) /= x_dimid .or. &
+       natts_in .ne. 0 .or. contiguous_in .neqv. .false. .or. &
+       chunksizes_in(1) /= chunksizes(1) .or. chunksizes_in(2) /= chunksizes(2) .or. &
+       deflate_level_in .ne. 4 .or. shuffle_in .neqv. .false. .or. fletcher32_in .neqv. .false.) &
+       stop 4
+
+  ! Check the data.
+  call handle_err(nf90_get_var(ncid, varid, data_in))
+  do x = 1, NX
+     do y = 1, NY
+        if (data_out(y, x) .ne. data_in(y, x)) stop 3
+     end do
+  end do
+
+  ! Close the file. 
+  call handle_err(nf90_close(ncid))
+
+  print *,'*** SUCCESS!'
+
+
+contains
+!     This subroutine handles errors by printing an error message and
+!     exiting with a non-zero status.
+  subroutine handle_err(errcode)
+    use netcdf
+    implicit none
+    integer, intent(in) :: errcode
+    
+    if(errcode /= nf90_noerr) then
+       print *, 'Error: ', trim(nf90_strerror(errcode))
+       stop 2
+    endif
+  end subroutine handle_err
+end program f90tst_var_szip

--- a/nf03_test4/f90tst_var_szip.f90
+++ b/nf03_test4/f90tst_var_szip.f90
@@ -1,10 +1,10 @@
 !     This is part of the netCDF package.
-!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
+!     Copyright 2020 University Corporation for Atmospheric Research/Unidata.
 !     See COPYRIGHT file for conditions of use.
 
 !     This program tests netCDF-4 variable functions from fortran.
 
-!     Ed Hartnett, 2009
+!     Ed Hartnett, 2/1/2020
 
 program f90tst_var_szip
   use typeSizes
@@ -32,7 +32,7 @@ program f90tst_var_szip
 
 
   print *, ''
-  print *,'*** Testing definition of netCDF-4 vars from Fortran 90.'
+  print *,'*** Testing szip writes of netCDF-4 var from Fortran 90.'
 
   ! Create some pretend data.
   do x = 1, NX
@@ -53,7 +53,10 @@ program f90tst_var_szip
   ! Define the variable. 
   chunksizes = (/ 256, 10 /)
   call handle_err(nf90_def_var(ncid, 'data', NF90_INT, dimids, & 
-       varid, chunksizes = chunksizes, deflate_level = 4))
+       varid, chunksizes = chunksizes))
+
+  ! Turn on szip compression.
+  call handle_err(nf90_def_var_szip(ncid, 1, 32, 4))
 
   ! With classic model netCDF-4 file, enddef must be called.
   call handle_err(nf90_enddef(ncid))
@@ -79,7 +82,7 @@ program f90tst_var_szip
        dimids_in(1) /= y_dimid .or. dimids_in(2) /= x_dimid .or. &
        natts_in .ne. 0 .or. contiguous_in .neqv. .false. .or. &
        chunksizes_in(1) /= chunksizes(1) .or. chunksizes_in(2) /= chunksizes(2) .or. &
-       deflate_level_in .ne. 4 .or. shuffle_in .neqv. .false. .or. fletcher32_in .neqv. .false.) &
+       shuffle_in .neqv. .false. .or. fletcher32_in .neqv. .false.) &
        stop 4
 
   ! Check the data.

--- a/nf_test4/Makefile.am
+++ b/nf_test4/Makefile.am
@@ -59,6 +59,9 @@ endif
 
 # Test szip
 if TEST_SZIP_WRITE
+check_PROGRAMS += ftst_var_szip
+ftst_var_szip_SOURCES = ftst_var_szip.F
+TESTS += ftst_var_szip
 endif
 
 # If sed is present, generate these tests at build time. They are the

--- a/nf_test4/Makefile.am
+++ b/nf_test4/Makefile.am
@@ -94,6 +94,13 @@ f03tst_parallel_SOURCES = f03tst_parallel.F
 TESTS += run_f77_par_test_03.sh
 endif # TEST_PARALLEL
 
+# Convert the szip test.
+if TEST_SZIP_WRITE
+F03_TEST_CODES += f03tst_var_szip.F
+F03_TESTS += f03tst_var_szip
+f03tst_var_szip_SOURCES = f03tst_var_szip.F
+endif
+
 # Note that all these fortran programs are built at compile-time on
 # the user system.
 BUILT_SOURCES = $(F03_TEST_CODES)
@@ -174,6 +181,11 @@ f03tst_parallel.F: ftst_parallel.F
 	$(SED) "s|implicit none|USE netcdf4_f03|" $< > $@.tmp
 	$(SED) "s|include 'netcdf.inc'|implicit none|" $@.tmp > $@.tmp2
 	$(SED) "s|ftst_parallel.nc|f03tst_parallel.nc|" $@.tmp2 > $@
+
+f03tst_var_szip.F: ftst_var_szip.F
+	$(SED) "s|implicit none|USE netcdf4_f03|" $< > $@.tmp
+	$(SED) "s|include 'netcdf.inc'|implicit none|" $@.tmp > $@.tmp2
+	$(SED) "s|ftst_var_szip.nc|f03tst_var_szip.nc|" $@.tmp2 > $@
 
 endif #USE_SED
 

--- a/nf_test4/Makefile.am
+++ b/nf_test4/Makefile.am
@@ -57,6 +57,10 @@ ftst_filter_SOURCES = ftst_filter.F
 TESTS += run_tst_filter.sh
 endif
 
+# Test szip
+if TEST_SZIP_WRITE
+endif
+
 # If sed is present, generate these tests at build time. They are the
 # same tests as the F77 netCDF-4 tests above, but using the "use
 # netcdf4_f03" statement.

--- a/nf_test4/Makefile.am
+++ b/nf_test4/Makefile.am
@@ -57,7 +57,7 @@ ftst_filter_SOURCES = ftst_filter.F
 TESTS += run_tst_filter.sh
 endif
 
-# Test szip
+# Test szip if write capability is present in C library.
 if TEST_SZIP_WRITE
 check_PROGRAMS += ftst_var_szip
 ftst_var_szip_SOURCES = ftst_var_szip.F
@@ -99,7 +99,7 @@ if TEST_SZIP_WRITE
 F03_TEST_CODES += f03tst_var_szip.F
 F03_TESTS += f03tst_var_szip
 f03tst_var_szip_SOURCES = f03tst_var_szip.F
-endif
+endif # TEST_SZIP_WRITE
 
 # Note that all these fortran programs are built at compile-time on
 # the user system.

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -43,7 +43,7 @@ C     Loop index and error handling.
       print *,'*** Testing szip compression.'
 
 C     Prepare some data to write.
-      do x = 1, data_len
+      do x = 1, DATA_LEN
          data1(x) = x
       end do
 
@@ -66,6 +66,10 @@ C     Create a few integer variables.
      $        varid(x))
          if (retval .ne. nf_noerr) stop 1
       end do
+
+C     Set an alternative fill value for the third variable.
+      retval = nf_def_var_fill(ncid, varid(3), 0, MY_FILL_VALUE)
+      if (retval .ne. 0) stop 3
 
 C     Write some data.
       retval = nf_put_var_int(ncid, varid(1), data1)
@@ -138,27 +142,26 @@ C     Get the varids and the dimid.
       if (retval .ne. nf_noerr) stop 1
       if (dimid_in .ne. 1) stop 7
 
-C     Get the data in var1. It will be all the default fill value.
+C     Get the data in var1. It will be values we have set.
       retval = nf_get_var_int(ncid, varid_in(1), int_data_in)
       if (retval .ne. nf_noerr) stop 1
       do x = 1, DIM_LEN
          if (int_data_in(x) .ne. x) stop 13
       end do
 
-C     Get the data in var2. What will it be?
+C     Get the data in var2. It will be default fill value.
       retval = nf_get_var_int(ncid, varid_in(2), int_data_in)
       if (retval .ne. nf_noerr) stop 1
-C$$$      do x = 1, DIM_LEN
-C$$$         print *, int_data_in(x)
-C$$$      end do
+      do x = 1, DIM_LEN
+         if (int_data_in(x) .ne. NF_FILL_INT) stop 13
+      end do
 
-C     Get the data in var3. It will be all the default fill value.
+C     Get the data in var3. It will be all the assigned fill value.
       retval = nf_get_var_int(ncid, varid_in(3), int_data_in)
       if (retval .ne. nf_noerr) stop 1
-c$$$      do x = 1, DIM_LEN
-c$$$C         print *, int_data_in(x)
-c$$$         if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14
-c$$$      end do
+      do x = 1, DIM_LEN
+         if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14
+      end do
 
       check_file = 0
       end 

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -52,7 +52,7 @@ C     Set up var names.
       var_name(2) = 'var2'
       var_name(3) = 'var3'
 
-      retval = nf_set_log_level(3)
+C      retval = nf_set_log_level(3)
 
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
@@ -74,7 +74,13 @@ C     Set an alternative fill value for the third variable.
       if (retval .ne. 0) stop 3
 
 C     Turn on szip compression for var 1.
-      retval = nf_def_var_szip(ncid, varid(1), 32, 4)
+      retval = nf_def_var_szip(ncid, varid(1),
+     $     nf_szip_ec_option_mask, 4)
+      if (retval .ne. 0) stop 3
+
+C     Turn on szip compression for var 3.
+      retval = nf_def_var_szip(ncid, varid(3),
+     $     nf_szip_nn_option_mask, 4)
       if (retval .ne. 0) stop 3
 
 C     Write some data.

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -52,6 +52,8 @@ C     Set up var names.
       var_name(2) = 'var2'
       var_name(3) = 'var3'
 
+      retval = nf_set_log_level(3)
+
 C     Create the netCDF file.
       retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
       if (retval .ne. nf_noerr) stop 1
@@ -72,7 +74,7 @@ C     Set an alternative fill value for the third variable.
       if (retval .ne. 0) stop 3
 
 C     Turn on szip compression for var 1.
-      retval = nf_def_var_szip(ncid, varid(1), 3)
+      retval = nf_def_var_szip(ncid, varid(1), 32, 4)
       if (retval .ne. 0) stop 3
 
 C     Write some data.

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -134,6 +134,7 @@ C     Values that are read in, to check the file.
       integer varid_in(NVARS), dimid_in, no_fill_in, fill_value_in
       character*(4) var_name_in
       integer int_data_in(DIM_LEN)
+      integer options_mask_in, pixels_per_block_in
 
       integer x, retval
 
@@ -160,6 +161,12 @@ C     Get the data in var1. It will be values we have set.
       do x = 1, DIM_LEN
          if (int_data_in(x) .ne. x) stop 13
       end do
+
+C     Get the szip settings for var1. H5Zszip code will sometimes bump
+C     the bits_per_pixel from 32 to 64 and may add other flags to the
+C     options_mask, so we don't check these values in this test.
+      retval = nf_inq_var_szip(ncid, varid_in(1), options_mask_in,
+     $     pixels_per_block_in)
 
 C     Get the data in var2. It will be default fill value.
       retval = nf_get_var_int(ncid, varid_in(2), int_data_in)

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -22,13 +22,13 @@ C     This is the name of the data file we will create.
       integer NVARS
       parameter (NVARS = 3)
       integer DATA_LEN
-      parameter (DATA_LEN = 2)
+      parameter (DATA_LEN = 22)
       integer check_file
 
       integer ncid, varid(NVARS), dimids(NDIMS)
       integer data_len_in, offset
       parameter (offset = 20)
-      integer data1(data_len), data1_in(data_len)
+      integer data1(DATA_LEN), data1_in(DATA_LEN)
       character*(4) var_name(NVARS)
       character*(4) dim_name
       parameter (dim_name = 'dim1')
@@ -67,6 +67,10 @@ C     Create a few integer variables.
          if (retval .ne. nf_noerr) stop 1
       end do
 
+C     Write some data.
+      retval = nf_put_var_int(ncid, varid(1), data1)
+      if (retval .ne. nf_noerr) stop 1
+
 C     Close the file.
       retval = nf_close(ncid)
       if (retval .ne. nf_noerr) stop 1
@@ -99,7 +103,7 @@ C     I need these in both here and the main program.
       integer NVARS
       parameter (NVARS = 3)
       integer DATA_LEN
-      parameter (DATA_LEN = 2)
+      parameter (DATA_LEN = 22)
       integer MY_FILL_VALUE
       parameter (MY_FILL_VALUE = 42)
 
@@ -138,7 +142,7 @@ C     Get the data in var1. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(1), int_data_in)
       if (retval .ne. nf_noerr) stop 1
       do x = 1, DIM_LEN
-         if (int_data_in(x) .ne. nf_fill_int) stop 13
+         if (int_data_in(x) .ne. x) stop 13
       end do
 
 C     Get the data in var2. What will it be?

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -1,0 +1,205 @@
+C     This is part of the netCDF package.
+C     Copyright 2020 University Corporation for Atmospheric Research/Unidata.
+C     See COPYRIGHT file for conditions of use.
+
+C     This program tests netCDF-4 szip compression. This test is only
+C     run if nc_def_var_szip() is found in netcdf-c, and also the HDF5
+C     instance upon which the netcdf-c depends was built with szip.
+
+C     Ed Hartnett, 1/31/20
+
+      program ftst_var_szip
+      implicit none
+      include 'netcdf.inc'
+
+C     This is the name of the data file we will create.
+      character*(*) FILE_NAME
+      parameter (FILE_NAME='ftst_var_szip.nc')
+      integer NDIMS
+      parameter (NDIMS = 1)
+      integer DIM_LEN
+      parameter (DIM_LEN = 22)
+      integer NVARS
+      parameter (NVARS = 3)
+      integer DATA_LEN
+      parameter (DATA_LEN = 2)
+      integer check_file
+
+      integer ncid, varid(NVARS), dimids(NDIMS)
+      integer data_len_in, offset
+      parameter (offset = 20)
+      integer data1(data_len), data1_in(data_len)
+      character*(4) var_name(NVARS)
+      character*(4) dim_name
+      parameter (dim_name = 'dim1')
+      integer NO_FILL, MY_FILL_VALUE
+      parameter (NO_FILL = 1)
+      parameter (MY_FILL_VALUE = 42)
+
+C     Loop index and error handling.
+      integer x, retval
+
+      print *, ''
+      print *,'*** Testing fill values.'
+
+C     Prepare some data to write.
+      do x = 1, data_len
+         data1(x) = x
+      end do
+
+C     Set up var names.
+      var_name(1) = 'var1'
+      var_name(2) = 'var2'
+      var_name(3) = 'var3'
+
+C     Create the netCDF file.
+      retval = nf_create(FILE_NAME, NF_NETCDF4, ncid)
+      if (retval .ne. nf_noerr) stop 1
+
+C     Create a dimension.
+      retval = nf_def_dim(ncid, dim_name, DIM_LEN, dimids(1))
+      if (retval .ne. nf_noerr) stop 1
+
+C     Create a few integer variables.
+      do x = 1, NVARS      
+         retval = nf_def_var(ncid, var_name(x), NF_INT, NDIMS, dimids,
+     $        varid(x))
+         if (retval .ne. nf_noerr) stop 1
+      end do
+
+C     Set no fill mode for the second variable.
+      retval = nf_def_var_fill(ncid, varid(2), NO_FILL, 88)
+      if (retval .ne. 0) stop 2
+
+C     Set an alternative fill value for the third variable.
+      retval = nf_def_var_fill(ncid, varid(3), 0, MY_FILL_VALUE)
+      if (retval .ne. 0) stop 3
+
+C     Check it out. 
+c     retval = check_file(ncid, var_name, dim_name)
+c     if (retval .ne. 0) stop 2
+
+C     Close the file. 
+      retval = nf_close(ncid)
+      if (retval .ne. nf_noerr) stop 1
+
+C     Reopen the file.
+      retval = nf_open(FILE_NAME, NF_NOWRITE, ncid)
+      if (retval .ne. nf_noerr) stop 1
+
+C     Check it out. 
+      retval = check_file(ncid, var_name, dim_name)
+      if (retval .ne. 0) stop 4
+
+C     Close the file. 
+      retval = nf_close(ncid)
+      if (retval .ne. nf_noerr) stop 1
+
+      print *,'*** SUCCESS!'
+      end
+
+C     This function check the file to make sure everything is OK.
+      integer function check_file(ncid, var_name, dim_name)
+      implicit none
+      include 'netcdf.inc'
+
+C     I need these in both here and the main program.
+      integer NDIMS
+      parameter (NDIMS = 1)
+      integer DIM_LEN
+      parameter (DIM_LEN = 22)
+      integer NVARS
+      parameter (NVARS = 3)
+      integer DATA_LEN
+      parameter (DATA_LEN = 2)
+      integer MY_FILL_VALUE
+      parameter (MY_FILL_VALUE = 42)
+
+C     Parameters
+      integer ncid
+      character*(4) var_name(NVARS)
+      character*(4) dim_name
+
+C     Values that are read in, to check the file.
+      integer ndims_in, nvars_in, ngatts_in, unlimdimid_in
+      integer xtype_in, dimids_in(NDIMS), natts_in
+      integer varid_in(NVARS), dimid_in, no_fill_in, fill_value_in
+      character*(4) var_name_in
+      integer int_data_in(DIM_LEN)
+
+      integer x, retval
+
+C     Check it out.
+      retval = nf_inq(ncid, ndims_in, nvars_in, ngatts_in,
+     $     unlimdimid_in)
+      if (retval .ne. nf_noerr) stop 1
+      if (ndims_in .ne. 1 .or. nvars_in .ne. NVARS .or. ngatts_in .ne. 0
+     $     .or. unlimdimid_in .ne. -1) stop 5
+
+C     Get the varids and the dimid.
+      do x = 1, NVARS      
+         retval = nf_inq_varid(ncid, var_name(x), varid_in(x))
+         if (retval .ne. nf_noerr) stop 1
+         if (varid_in(x) .ne. x) stop 6
+      end do
+      retval = nf_inq_dimid(ncid, dim_name, dimid_in)
+      if (retval .ne. nf_noerr) stop 1
+      if (dimid_in .ne. 1) stop 7
+
+C     These things are the same for all three variables, except
+C     natts_in..
+      do x = 1, NVARS      
+         retval = nf_inq_var(ncid, varid_in(x), var_name_in, xtype_in,
+     $        ndims_in, dimids_in, natts_in)
+         if (retval .ne. nf_noerr) stop 1
+         if (ndims_in .ne. 1 .or. xtype_in .ne. NF_INT .or. dimids_in(1)
+     $        .ne. dimid_in) stop 8
+         if (x .eq. 3 .and. natts_in .ne. 1) stop 9
+         if (x .lt. 3 .and. natts_in .ne. 0) stop 10
+      end do
+
+C     Check the fill value for the first var. Nothing was set, so
+C     no_fill should be off, and fill_value should be the default fill
+C     value for this type.
+      retval = nf_inq_var_fill(ncid, varid_in(1), no_fill_in,
+     $     fill_value_in)
+      if (retval .ne. nf_noerr) stop 1
+      if (no_fill_in .ne. 0 .or. fill_value_in .ne. nf_fill_int) stop 11
+
+C     Check that no_fill mode is on for the second variable.
+      retval = nf_inq_var_fill(ncid, varid_in(2), no_fill_in,
+     $     fill_value_in)
+      if (retval .ne. nf_noerr) stop 1
+      if (no_fill_in .ne. 1 .or. fill_value_in .ne. nf_fill_int) stop 12
+
+C     Check that a non-default fill value is in use for the third variable.
+      retval = nf_inq_var_fill(ncid, varid_in(3), no_fill_in,
+     $     fill_value_in)
+      if (retval .ne. nf_noerr) stop 1
+      if (no_fill_in .ne. 0 .or. fill_value_in .ne. MY_FILL_VALUE) stop
+     $     2
+
+C     Get the data in var1. It will be all the default fill value.
+      retval = nf_get_var_int(ncid, varid_in(1), int_data_in)
+      if (retval .ne. nf_noerr) stop 1
+      do x = 1, DIM_LEN
+         if (int_data_in(x) .ne. nf_fill_int) stop 13
+      end do
+
+C     Get the data in var2. What will it be?
+      retval = nf_get_var_int(ncid, varid_in(2), int_data_in)
+      if (retval .ne. nf_noerr) stop 1
+C$$$      do x = 1, DIM_LEN
+C$$$         print *, int_data_in(x)
+C$$$      end do
+
+C     Get the data in var3. It will be all the default fill value.
+      retval = nf_get_var_int(ncid, varid_in(3), int_data_in)
+      if (retval .ne. nf_noerr) stop 1
+      do x = 1, DIM_LEN
+C         print *, int_data_in(x)
+         if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14
+      end do
+
+      check_file = 0
+      end 

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -40,7 +40,7 @@ C     Loop index and error handling.
       integer x, retval
 
       print *, ''
-      print *,'*** Testing fill values.'
+      print *,'*** Testing szip compression.'
 
 C     Prepare some data to write.
       do x = 1, data_len
@@ -67,19 +67,7 @@ C     Create a few integer variables.
          if (retval .ne. nf_noerr) stop 1
       end do
 
-C     Set no fill mode for the second variable.
-      retval = nf_def_var_fill(ncid, varid(2), NO_FILL, 88)
-      if (retval .ne. 0) stop 2
-
-C     Set an alternative fill value for the third variable.
-      retval = nf_def_var_fill(ncid, varid(3), 0, MY_FILL_VALUE)
-      if (retval .ne. 0) stop 3
-
-C     Check it out. 
-c     retval = check_file(ncid, var_name, dim_name)
-c     if (retval .ne. 0) stop 2
-
-C     Close the file. 
+C     Close the file.
       retval = nf_close(ncid)
       if (retval .ne. nf_noerr) stop 1
 
@@ -146,39 +134,6 @@ C     Get the varids and the dimid.
       if (retval .ne. nf_noerr) stop 1
       if (dimid_in .ne. 1) stop 7
 
-C     These things are the same for all three variables, except
-C     natts_in..
-      do x = 1, NVARS      
-         retval = nf_inq_var(ncid, varid_in(x), var_name_in, xtype_in,
-     $        ndims_in, dimids_in, natts_in)
-         if (retval .ne. nf_noerr) stop 1
-         if (ndims_in .ne. 1 .or. xtype_in .ne. NF_INT .or. dimids_in(1)
-     $        .ne. dimid_in) stop 8
-         if (x .eq. 3 .and. natts_in .ne. 1) stop 9
-         if (x .lt. 3 .and. natts_in .ne. 0) stop 10
-      end do
-
-C     Check the fill value for the first var. Nothing was set, so
-C     no_fill should be off, and fill_value should be the default fill
-C     value for this type.
-      retval = nf_inq_var_fill(ncid, varid_in(1), no_fill_in,
-     $     fill_value_in)
-      if (retval .ne. nf_noerr) stop 1
-      if (no_fill_in .ne. 0 .or. fill_value_in .ne. nf_fill_int) stop 11
-
-C     Check that no_fill mode is on for the second variable.
-      retval = nf_inq_var_fill(ncid, varid_in(2), no_fill_in,
-     $     fill_value_in)
-      if (retval .ne. nf_noerr) stop 1
-      if (no_fill_in .ne. 1 .or. fill_value_in .ne. nf_fill_int) stop 12
-
-C     Check that a non-default fill value is in use for the third variable.
-      retval = nf_inq_var_fill(ncid, varid_in(3), no_fill_in,
-     $     fill_value_in)
-      if (retval .ne. nf_noerr) stop 1
-      if (no_fill_in .ne. 0 .or. fill_value_in .ne. MY_FILL_VALUE) stop
-     $     2
-
 C     Get the data in var1. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(1), int_data_in)
       if (retval .ne. nf_noerr) stop 1
@@ -196,10 +151,10 @@ C$$$      end do
 C     Get the data in var3. It will be all the default fill value.
       retval = nf_get_var_int(ncid, varid_in(3), int_data_in)
       if (retval .ne. nf_noerr) stop 1
-      do x = 1, DIM_LEN
-C         print *, int_data_in(x)
-         if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14
-      end do
+c$$$      do x = 1, DIM_LEN
+c$$$C         print *, int_data_in(x)
+c$$$         if (int_data_in(x) .ne. MY_FILL_VALUE) stop 14
+c$$$      end do
 
       check_file = 0
       end 

--- a/nf_test4/ftst_var_szip.F
+++ b/nf_test4/ftst_var_szip.F
@@ -71,6 +71,10 @@ C     Set an alternative fill value for the third variable.
       retval = nf_def_var_fill(ncid, varid(3), 0, MY_FILL_VALUE)
       if (retval .ne. 0) stop 3
 
+C     Turn on szip compression for var 1.
+      retval = nf_def_var_szip(ncid, varid(1), 3)
+      if (retval .ne. 0) stop 3
+
 C     Write some data.
       retval = nf_put_var_int(ncid, varid(1), data1)
       if (retval .ne. nf_noerr) stop 1


### PR DESCRIPTION
In this PR I add support for nc_def_var_szip to the F77 and F90 APIs, including tests.

Since this is adding a new function, only the current C master will work to build this. So this will fail travis. I suppose, @WardF , that you will want to release the C version, then update the Fortran tavis testing, then this PR will pass tests.

Fixes #215 
Fixes #213 