### PR TITLE
Fix warnings and documentation in examples

### DIFF
--- a/examples/F77/pres_temp_4D_rd.f
+++ b/examples/F77/pres_temp_4D_rd.f
@@ -8,10 +8,10 @@ C     the companion program pres_temp_4D_wr.f. It is intended to
 C     illustrate the use of the netCDF Fortran 77 API.
 
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/pres_temp_4D_rd.f
+++ b/examples/F77/pres_temp_4D_rd.f
@@ -8,12 +8,12 @@ C     the companion program pres_temp_4D_wr.f. It is intended to
 C     illustrate the use of the netCDF Fortran 77 API.
 
 C     This program is part of the netCDF tutorial:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
-C     $Id: pres_temp_4D_rd.f,v 1.12 2007/02/14 20:59:20 ed Exp $
+C     Ed Hartnett
 
       program pres_temp_4D_rd
       implicit none
@@ -34,7 +34,6 @@ C     timesteps of data.
       parameter (LVL_NAME = 'level')
       parameter (LAT_NAME = 'latitude', LON_NAME = 'longitude')
       parameter (REC_NAME = 'time')
-      integer lvl_dimid, lon_dimid, lat_dimid, rec_dimid
 
 C     The start and count arrays will tell the netCDF library where to
 C     read our data.
@@ -54,7 +53,6 @@ C     terminology these are called "variables."
       parameter (PRES_NAME='pressure')
       parameter (TEMP_NAME='temperature')
       integer pres_varid, temp_varid
-      integer dimids(NDIMS)
 
 C     We recommend that each variable carry a "units" attribute.
       character*(*) UNITS

--- a/examples/F77/pres_temp_4D_wr.f
+++ b/examples/F77/pres_temp_4D_wr.f
@@ -8,10 +8,10 @@ C     fortran 77 API. The companion program pres_temp_4D_rd.f shows how
 C     to read the netCDF data file created by this program.
 
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/pres_temp_4D_wr.f
+++ b/examples/F77/pres_temp_4D_wr.f
@@ -8,12 +8,12 @@ C     fortran 77 API. The companion program pres_temp_4D_rd.f shows how
 C     to read the netCDF data file created by this program.
 
 C     This program is part of the netCDF tutorial:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
-C     $Id: pres_temp_4D_wr.f,v 1.12 2007/02/14 20:59:20 ed Exp $
+C     Ed Hartnett
 
       program pres_temp_4D_wr
       implicit none

--- a/examples/F77/sfc_pres_temp_rd.f
+++ b/examples/F77/sfc_pres_temp_rd.f
@@ -8,12 +8,12 @@ C     comapnion program sfc_pres_temp_wr.f. It is intended to illustrate
 C     the use of the netCDF fortran 77 API.
 
 C     This program is part of the netCDF tutorial:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
-C     $Id: sfc_pres_temp_rd.f,v 1.9 2007/02/14 20:59:20 ed Exp $
+C     Ed Hartnett
 
       program sfc_pres_temp_rd
       implicit none
@@ -31,7 +31,6 @@ C     We are reading 2D data, a 12 x 6 lon-lat grid.
       parameter (NLATS = 6, NLONS = 12)
       character*(*) LAT_NAME, LON_NAME
       parameter (LAT_NAME='latitude', LON_NAME='longitude')
-      integer lat_dimid, lon_dimid
 
 C     For the lat lon coordinate netCDF variables.
       real lats(NLATS), lons(NLONS)
@@ -42,7 +41,6 @@ C     We will read surface temperature and pressure fields.
       parameter (PRES_NAME='pressure')
       parameter (TEMP_NAME='temperature')
       integer pres_varid, temp_varid
-      integer dimids(NDIMS)
 
 C     To check the units attributes.
       character*(*) UNITS

--- a/examples/F77/sfc_pres_temp_rd.f
+++ b/examples/F77/sfc_pres_temp_rd.f
@@ -8,10 +8,10 @@ C     comapnion program sfc_pres_temp_wr.f. It is intended to illustrate
 C     the use of the netCDF fortran 77 API.
 
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/sfc_pres_temp_wr.f
+++ b/examples/F77/sfc_pres_temp_wr.f
@@ -8,12 +8,12 @@ C     companion program sfc_pres_temp_rd.f shows how to read the netCDF
 C     data file created by this program.
 
 C     This program is part of the netCDF tutorial:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
-C     $Id: sfc_pres_temp_wr.f,v 1.10 2007/02/14 20:59:20 ed Exp $
+C     Ed Hartnett
 
       program sfc_pres_temp_wr
       implicit none

--- a/examples/F77/sfc_pres_temp_wr.f
+++ b/examples/F77/sfc_pres_temp_wr.f
@@ -8,10 +8,10 @@ C     companion program sfc_pres_temp_rd.f shows how to read the netCDF
 C     data file created by this program.
 
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/simple_xy_nc4_rd.f
+++ b/examples/F77/simple_xy_nc4_rd.f
@@ -5,15 +5,13 @@ C     See COPYRIGHT file for conditions of use.
 C     This is a simple example which reads a small dummy array, from a
 C     netCDF data file created by the companion program simple_xy_wr.f.
       
-C     This is intended to illustrate the use of the netCDF fortran 77
-C     API. This example program is part of the netCDF tutorial, which can
-C     be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     This program is part of the netCDF tutorial:
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-C     $Id: simple_xy_nc4_rd.f,v 1.1 2007/05/04 13:33:20 ed Exp $
+C     Full documentation of the netCDF Fortran 77 API can be found at:
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+
+C     Ed Hartnett
 
       program simple_xy_rd
       implicit none

--- a/examples/F77/simple_xy_nc4_rd.f
+++ b/examples/F77/simple_xy_nc4_rd.f
@@ -6,10 +6,10 @@ C     This is a simple example which reads a small dummy array, from a
 C     netCDF data file created by the companion program simple_xy_wr.f.
       
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/simple_xy_nc4_wr.f
+++ b/examples/F77/simple_xy_nc4_wr.f
@@ -6,14 +6,13 @@ C     This is a very simple example which writes a 2D array of
 C     sample data. To handle this in netCDF we create two shared
 C     dimensions, "x" and "y", and a netCDF variable, called "data".
 
-C     This example demonstrates the netCDF Fortran 77 API. This is part
-C     of the netCDF tutorial, which can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+C     This program is part of the netCDF tutorial:
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
-C     $Id: simple_xy_nc4_wr.f,v 1.5 2008/02/19 22:01:49 ed Exp $
+C     Ed Hartnett
 
       program simple_xy_wr
       implicit none

--- a/examples/F77/simple_xy_nc4_wr.f
+++ b/examples/F77/simple_xy_nc4_wr.f
@@ -7,10 +7,10 @@ C     sample data. To handle this in netCDF we create two shared
 C     dimensions, "x" and "y", and a netCDF variable, called "data".
 
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/simple_xy_rd.f
+++ b/examples/F77/simple_xy_rd.f
@@ -5,15 +5,13 @@ C     See COPYRIGHT file for conditions of use.
 C     This is a simple example which reads a small dummy array, from a
 C     netCDF data file created by the companion program simple_xy_wr.f.
       
-C     This is intended to illustrate the use of the netCDF fortran 77
-C     API. This example program is part of the netCDF tutorial, which can
-C     be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     This program is part of the netCDF tutorial:
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-C     $Id: simple_xy_rd.f,v 1.8 2007/02/14 20:59:20 ed Exp $
+C     Full documentation of the netCDF Fortran 77 API can be found at:
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+
+C     Ed Hartnett
 
       program simple_xy_rd
       implicit none

--- a/examples/F77/simple_xy_rd.f
+++ b/examples/F77/simple_xy_rd.f
@@ -6,10 +6,10 @@ C     This is a simple example which reads a small dummy array, from a
 C     netCDF data file created by the companion program simple_xy_wr.f.
       
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/simple_xy_wr.f
+++ b/examples/F77/simple_xy_wr.f
@@ -7,10 +7,10 @@ C     sample data. To handle this in netCDF we create two shared
 C     dimensions, "x" and "y", and a netCDF variable, called "data".
 
 C     This program is part of the netCDF tutorial:
-C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+C     http://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
 
 C     Ed Hartnett
 

--- a/examples/F77/simple_xy_wr.f
+++ b/examples/F77/simple_xy_wr.f
@@ -6,14 +6,13 @@ C     This is a very simple example which writes a 2D array of
 C     sample data. To handle this in netCDF we create two shared
 C     dimensions, "x" and "y", and a netCDF variable, called "data".
 
-C     This example demonstrates the netCDF Fortran 77 API. This is part
-C     of the netCDF tutorial, which can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-C     Full documentation of the netCDF Fortran 77 API can be found at:
-C     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f77
+C     This program is part of the netCDF tutorial:
+C     https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-C     $Id: simple_xy_wr.f,v 1.11 2008/08/20 22:29:56 russ Exp $
+C     Full documentation of the netCDF Fortran 77 API can be found at:
+C     https://www.unidata.ucar.edu/software/netcdf/docs-fortran/nc_f77_interface_guide.html
+
+C     Ed Hartnett
 
       program simple_xy_wr
       implicit none

--- a/examples/F90/nc4_pres_temp_4D_wr.f90
+++ b/examples/F90/nc4_pres_temp_4D_wr.f90
@@ -8,10 +8,10 @@
 ! to read the netCDF data file created by this program.
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/nc4_pres_temp_4D_wr.f90
+++ b/examples/F90/nc4_pres_temp_4D_wr.f90
@@ -8,12 +8,12 @@
 ! to read the netCDF data file created by this program.
 
 ! This program is part of the netCDF tutorial:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
-! $Id: nc4_pres_temp_4D_wr.f90,v 1.10 2010/04/06 19:32:09 ed Exp $
+! Ed Hartnett
 
 program nc4_pres_temp_4D_wr
   use netcdf

--- a/examples/F90/pres_temp_4D_rd.f90
+++ b/examples/F90/pres_temp_4D_rd.f90
@@ -8,10 +8,10 @@
 ! illustrate the use of the netCDF Fortran 90 API.
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/pres_temp_4D_rd.f90
+++ b/examples/F90/pres_temp_4D_rd.f90
@@ -8,12 +8,12 @@
 ! illustrate the use of the netCDF Fortran 90 API.
 
 ! This program is part of the netCDF tutorial:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
-! $Id: pres_temp_4D_rd.f90,v 1.9 2010/04/06 19:32:09 ed Exp $
+! Ed Hartnett
 
 program pres_temp_4D_rd
   use netcdf

--- a/examples/F90/pres_temp_4D_wr.f90
+++ b/examples/F90/pres_temp_4D_wr.f90
@@ -8,12 +8,12 @@
 ! to read the netCDF data file created by this program.
 
 ! This program is part of the netCDF tutorial:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
-! $Id: pres_temp_4D_wr.f90,v 1.10 2010/04/06 19:32:09 ed Exp $
+! Ed Hartnett
 
 program pres_temp_4D_wr
   use netcdf

--- a/examples/F90/pres_temp_4D_wr.f90
+++ b/examples/F90/pres_temp_4D_wr.f90
@@ -8,10 +8,10 @@
 ! to read the netCDF data file created by this program.
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/sfc_pres_temp_rd.f90
+++ b/examples/F90/sfc_pres_temp_rd.f90
@@ -8,10 +8,10 @@
 ! the use of the netCDF fortran 90 API.
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/sfc_pres_temp_rd.f90
+++ b/examples/F90/sfc_pres_temp_rd.f90
@@ -8,12 +8,12 @@
 ! the use of the netCDF fortran 90 API.
 
 ! This program is part of the netCDF tutorial:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
-! $Id: sfc_pres_temp_rd.f90,v 1.10 2010/04/06 19:32:09 ed Exp $
+! Ed Hartnett
 
 program sfc_pres_temp_rd
   use netcdf

--- a/examples/F90/sfc_pres_temp_wr.f90
+++ b/examples/F90/sfc_pres_temp_wr.f90
@@ -8,10 +8,10 @@
 ! data file created by this program.
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/sfc_pres_temp_wr.f90
+++ b/examples/F90/sfc_pres_temp_wr.f90
@@ -8,12 +8,12 @@
 ! data file created by this program.
 
 ! This program is part of the netCDF tutorial:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
-! $Id: sfc_pres_temp_wr.f90,v 1.12 2010/04/06 19:32:09 ed Exp $
+! Ed Hartnett
 
 program sfc_pres_temp_wr
   use netcdf

--- a/examples/F90/simple_xy_nc4_rd.f90
+++ b/examples/F90/simple_xy_nc4_rd.f90
@@ -5,15 +5,13 @@
 ! This is a simple example which reads a small dummy array, from a
 ! netCDF data file created by the companion program simple_xy_wr.f90.
       
-! This is intended to illustrate the use of the netCDF fortran 77
-! API. This example program is part of the netCDF tutorial, which can
-! be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-! $Id: simple_xy_nc4_rd.f90,v 1.3 2009/02/25 12:23:45 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 program simple_xy_rd
   use netcdf

--- a/examples/F90/simple_xy_nc4_rd.f90
+++ b/examples/F90/simple_xy_nc4_rd.f90
@@ -6,10 +6,10 @@
 ! netCDF data file created by the companion program simple_xy_wr.f90.
       
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/simple_xy_nc4_wr.f90
+++ b/examples/F90/simple_xy_nc4_wr.f90
@@ -7,10 +7,10 @@
 ! and "y", and a netCDF variable, called "data".
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/simple_xy_nc4_wr.f90
+++ b/examples/F90/simple_xy_nc4_wr.f90
@@ -1,19 +1,18 @@
-!     This is part of the netCDF package.  Copyright 2006 University
-!     Corporation for Atmospheric Research/Unidata.  See COPYRIGHT
-!     file for conditions of use.
+! This is part of the netCDF package.  Copyright 2006 University
+! Corporation for Atmospheric Research/Unidata.  See COPYRIGHT file
+! for conditions of use.
 
-!     This is a very simple example which writes a 2D array of sample
-!     data. To handle this in netCDF we create two shared dimensions,
-!     "x" and "y", and a netCDF variable, called "data".
+! This is a very simple example which writes a 2D array of sample
+! data. To handle this in netCDF we create two shared dimensions, "x"
+! and "y", and a netCDF variable, called "data".
 
-!     This example demonstrates the netCDF Fortran 90 API. This is
-!     part of the netCDF tutorial, which can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-!     Full documentation of the netCDF Fortran 90 API can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-!     $Id: simple_xy_nc4_wr.f90,v 1.6 2010/04/06 19:32:09 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 program simple_xy_wr
   use netcdf

--- a/examples/F90/simple_xy_par_rd.f90
+++ b/examples/F90/simple_xy_par_rd.f90
@@ -6,15 +6,13 @@
 ! netCDF data file created by the companion program
 ! simple_xy_par_wr.f90. The data are read using parallel I/O.
       
-! This is intended to illustrate the use of the netCDF fortran 90
-! API. This example program is part of the netCDF tutorial, which can
-! be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-! $Id: simple_xy_par_rd.f90,v 1.2 2009/03/12 18:30:41 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 program simple_xy_par_rd
   use netcdf

--- a/examples/F90/simple_xy_par_rd.f90
+++ b/examples/F90/simple_xy_par_rd.f90
@@ -7,10 +7,10 @@
 ! simple_xy_par_wr.f90. The data are read using parallel I/O.
       
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/simple_xy_par_wr.f90
+++ b/examples/F90/simple_xy_par_wr.f90
@@ -1,21 +1,19 @@
-!     This is part of the netCDF package.
-!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
-!     See COPYRIGHT file for conditions of use.
+! This is part of the netCDF package.  Copyright 2006 University
+! Corporation for Atmospheric Research/Unidata.  See COPYRIGHT file
+! for conditions of use.
 
-!     This is a very simple example which writes a 2D array of sample
-!     data. To handle this in netCDF we create two shared dimensions,
-!     "x" and "y", and a netCDF variable, called "data". It uses
-!     parallel I/O to write the file from all processors at the same
-!     time.
+! This is a very simple example which writes a 2D array of sample
+! data. To handle this in netCDF we create two shared dimensions, "x"
+! and "y", and a netCDF variable, called "data". It uses parallel I/O
+! to write the file from all processors at the same time.
 
-!     This example demonstrates the netCDF Fortran 90 API. This is part
-!     of the netCDF tutorial, which can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-!     Full documentation of the netCDF Fortran 90 API can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-!     $Id: simple_xy_par_wr.f90,v 1.3 2010/06/01 15:34:49 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 program simple_xy_par_wr
   use netcdf

--- a/examples/F90/simple_xy_par_wr.f90
+++ b/examples/F90/simple_xy_par_wr.f90
@@ -8,10 +8,10 @@
 ! to write the file from all processors at the same time.
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/simple_xy_par_wr2.f90
+++ b/examples/F90/simple_xy_par_wr2.f90
@@ -15,10 +15,10 @@
 ! - include first process for opening/metadata/closing file
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Russ Rew, Marshall Ward, Ed Hartnett
 

--- a/examples/F90/simple_xy_par_wr2.f90
+++ b/examples/F90/simple_xy_par_wr2.f90
@@ -7,20 +7,20 @@
 ! and "y", and a netCDF variable, called "data". It uses parallel I/O
 ! to write the file from all processors at the same time.
 
-! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
-
-! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
-
-! Ed Hartnett
-
 ! Reto Stockli: added (to demonstrate parallel bug)
 ! - added unlimited time dimension (3)
 ! - added chunk size for unlimited variable writes
 ! - use of MPI module instead of include file
 ! - exclude first process from writing data (test independent write). 
 ! - include first process for opening/metadata/closing file
+
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Russ Rew, Marshall Ward, Ed Hartnett
 
 program simple_xy_par_wr2
 

--- a/examples/F90/simple_xy_par_wr2.f90
+++ b/examples/F90/simple_xy_par_wr2.f90
@@ -1,21 +1,19 @@
-!     This is part of the netCDF package.
-!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
-!     See COPYRIGHT file for conditions of use.
+! This is part of the netCDF package.  Copyright 2006 University
+! Corporation for Atmospheric Research/Unidata.  See COPYRIGHT file
+! for conditions of use.
 
-!     This is a very simple example which writes a 2D array of sample
-!     data. To handle this in netCDF we create two shared dimensions,
-!     "x" and "y", and a netCDF variable, called "data". It uses
-!     parallel I/O to write the file from all processors at the same
-!     time.
+! This is a very simple example which writes a 2D array of sample
+! data. To handle this in netCDF we create two shared dimensions, "x"
+! and "y", and a netCDF variable, called "data". It uses parallel I/O
+! to write the file from all processors at the same time.
 
-!     This example demonstrates the netCDF Fortran 90 API. This is part
-!     of the netCDF tutorial, which can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-!     Full documentation of the netCDF Fortran 90 API can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-!     $Id: simple_xy_par_wr.f90,v 1.3 2010/06/01 15:34:49 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 ! Reto Stockli: added (to demonstrate parallel bug)
 ! - added unlimited time dimension (3)
@@ -24,7 +22,7 @@
 ! - exclude first process from writing data (test independent write). 
 ! - include first process for opening/metadata/closing file
 
-program simple_xy_par_wr
+program simple_xy_par_wr2
 
   use netcdf
   use mpi
@@ -136,5 +134,5 @@ contains
       stop 2
     end if
   end subroutine check  
-end program simple_xy_par_wr
+end program simple_xy_par_wr2
 

--- a/examples/F90/simple_xy_par_wr2.f90
+++ b/examples/F90/simple_xy_par_wr2.f90
@@ -1,5 +1,5 @@
-! This is part of the netCDF package.  Copyright 2006 University
-! Corporation for Atmospheric Research/Unidata.  See COPYRIGHT file
+! This is part of the netCDF package. Copyright 2006 University
+! Corporation for Atmospheric Research/Unidata. See COPYRIGHT file
 ! for conditions of use.
 
 ! This is a very simple example which writes a 2D array of sample
@@ -7,7 +7,7 @@
 ! and "y", and a netCDF variable, called "data". It uses parallel I/O
 ! to write the file from all processors at the same time.
 
-! Reto Stockli: added (to demonstrate parallel bug)
+! This example is like simple_xy_par_wr.f90, except:
 ! - added unlimited time dimension (3)
 ! - added chunk size for unlimited variable writes
 ! - use of MPI module instead of include file

--- a/examples/F90/simple_xy_rd.f90
+++ b/examples/F90/simple_xy_rd.f90
@@ -5,15 +5,13 @@
 ! This is a simple example which reads a small dummy array, from a
 ! netCDF data file created by the companion program simple_xy_wr.f90.
       
-! This is intended to illustrate the use of the netCDF fortran 90
-! API. This example program is part of the netCDF tutorial, which can
-! be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-! Full documentation of the netCDF Fortran 90 API can be found at:
-! http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-! $Id: simple_xy_rd.f90,v 1.11 2010/04/06 19:32:09 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 program simple_xy_rd
   use netcdf

--- a/examples/F90/simple_xy_rd.f90
+++ b/examples/F90/simple_xy_rd.f90
@@ -6,10 +6,10 @@
 ! netCDF data file created by the companion program simple_xy_wr.f90.
       
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/simple_xy_wr.f90
+++ b/examples/F90/simple_xy_wr.f90
@@ -7,10 +7,10 @@
 ! and "y", and a netCDF variable, called "data".
 
 ! This program is part of the netCDF tutorial:
-! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
+! http://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
 ! Full documentation of the netCDF Fortran 90 API can be found at:
-! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+! http://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
 
 ! Ed Hartnett
 

--- a/examples/F90/simple_xy_wr.f90
+++ b/examples/F90/simple_xy_wr.f90
@@ -1,19 +1,18 @@
-!     This is part of the netCDF package.
-!     Copyright 2006 University Corporation for Atmospheric Research/Unidata.
-!     See COPYRIGHT file for conditions of use.
+! This is part of the netCDF package.  Copyright 2006 University
+! Corporation for Atmospheric Research/Unidata.  See COPYRIGHT file
+! for conditions of use.
 
-!     This is a very simple example which writes a 2D array of
-!     sample data. To handle this in netCDF we create two shared
-!     dimensions, "x" and "y", and a netCDF variable, called "data".
+! This is a very simple example which writes a 2D array of sample
+! data. To handle this in netCDF we create two shared dimensions, "x"
+! and "y", and a netCDF variable, called "data".
 
-!     This example demonstrates the netCDF Fortran 90 API. This is part
-!     of the netCDF tutorial, which can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-tutorial
-      
-!     Full documentation of the netCDF Fortran 90 API can be found at:
-!     http://www.unidata.ucar.edu/software/netcdf/docs/netcdf-f90
+! This program is part of the netCDF tutorial:
+! https://www.unidata.ucar.edu/software/netcdf/docs/tutorial_8dox.html
 
-!     $Id: simple_xy_wr.f90,v 1.11 2010/04/06 19:32:08 ed Exp $
+! Full documentation of the netCDF Fortran 90 API can be found at:
+! https://www.unidata.ucar.edu/software/netcdf/docs-fortran/f90_The-NetCDF-Fortran-90-Interface-Guide.html
+
+! Ed Hartnett
 
 program simple_xy_wr
   use netcdf


### PR DESCRIPTION
Fixes #233 
Fixes #232 

This PR contains some updated locations for the documentation, plus clears up compile warnings in the examples.

