### PR TITLE
Add missing build dependencies for Fortran

### DIFF
--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -37,7 +37,7 @@ libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
 libnetcdff_la_SOURCES = nf_attio.F90 nf_control.F90 nf_dim.f90		\
 nf_misc.f90 nf_genatt.f90 nf_geninq.f90 nf_genvar.f90 nf_vario.F90	\
 nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90			\
-nf_logging.F90
+nf_logging.F90 nf_nc.f90
 
 # Different source for the netcdf.mod is used for netcdf classic
 # vs. netcdf4.
@@ -82,6 +82,7 @@ module_netcdf_nc_interfaces.$(OBJEXT): netcdf_nc_data.mod
 module_netcdf4_nc_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
 module_netcdf_nf_interfaces.$(OBJEXT): netcdf_nf_data.mod
 module_netcdf_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod
+nf_nc.$(OBJEXT): netcdf_nc_interfaces.mod
 
 # Mod files are built and then installed as headers. Order is
 # significant in this list of modfiles.
@@ -103,8 +104,6 @@ MODFILES += netcdf_fortv2_c_interfaces.mod
 libnetcdff_la_SOURCES += nf_v2compat.c nf_fortv2.f90
 libnetcdff_la_LIBADD += libnetcdf_fortv2_c_interfaces.la
 endif # BUILD_V2
-
-libnetcdff_la_SOURCES += nf_nc.f90
 
 # Are we building netCDF-4?
 if USE_NETCDF4

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -39,6 +39,11 @@ nf_misc.f90 nf_genatt.f90 nf_geninq.f90 nf_genvar.f90 nf_vario.F90	\
 nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90			\
 nf_logging.F90 nf_nc.f90
 
+# The respective objects depend on the netcdf_nc_interfaces module.
+￼nf_attio.lo nf_control.lo nf_dim.lo nf_genatt.lo nf_geninq.lo nf_genvar.lo    \
+￼nf_misc.lo nf_var1io.lo nf_varaio.lo nf_vario.lo nf_varmio.lo                 \
+￼nf_varsio.lo: $(netcdf_nc_interfaces_mod)
+
 # Different source for the netcdf.mod is used for netcdf classic
 # vs. netcdf4.
 if USE_NETCDF4
@@ -100,6 +105,7 @@ noinst_LTLIBRARIES += libnetcdf_fortv2_c_interfaces.la
 libnetcdf_fortv2_c_interfaces_la_SOURCES = module_netcdf_fortv2_c_interfaces.f90
 netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.$(OBJEXT)
 module_netcdf_fortv2_c_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
+nf_fortv2.$(OBJEXT): $(netcdf_fortv2_c_interfaces_mod) $(netcdf_nc_interfaces_mod)
 MODFILES += netcdf_fortv2_c_interfaces.mod
 libnetcdff_la_SOURCES += nf_v2compat.c nf_fortv2.f90
 libnetcdff_la_LIBADD += libnetcdf_fortv2_c_interfaces.la

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -18,15 +18,20 @@ libnetcdff_la_LDFLAGS = -version-info 7:0:0
 
 # These f90 codes are used for either netCDF classic or netCDF-4 F90
 # API.
-COMMON_CODES = netcdf_constants.f90 netcdf_externals.f90		\
-netcdf_dims.f90 netcdf_attributes.f90 netcdf_overloads.f90		\
-netcdf_visibility.f90 netcdf_file.f90 netcdf_variables.f90		\
-netcdf_text_variables.f90 netcdf_expanded.f90 netcdf_eightbyte.f90
+COMMON_CODES = netcdf_constants.f90 netcdf_externals.f90	\
+netcdf_dims.f90 netcdf_attributes.f90 netcdf_overloads.f90	\
+netcdf_visibility.f90 netcdf_file.f90 netcdf_text_variables.f90	\
+netcdf_expanded.f90
 
 # These f90 codes are used for the netCDF-4 F90 API.
 NETCDF4_CODES = netcdf4_externals.f90 netcdf4_visibility.f90	\
 netcdf4_func.f90 netcdf4_overloads.f90 netcdf4_file.f90		\
 netcdf4_eightbyte.f90 netcdf4_variables.f90
+
+# These f90 codes are used in the netCDF classic API, when netCDF/HDF5
+# is not being built.
+NETCDF3_CODES = netcdf_eightbyte.f90 netcdf3_file.f90	\
+netcdf_variables.f90
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = libtypeSizes.la libnetcdf_nc_data.la	\
@@ -50,7 +55,7 @@ if USE_NETCDF4
 
 # Use the netCDF-4 F90 code.
 libnetcdfm_la_SOURCES = netcdf4.f90
-netcdf4.$(OBJEXT): typesizes.mod
+netcdf4.$(OBJEXT): typesizes.mod $(COMMON_CODES) $(NETCDF4_CODES)
 netcdf.mod: netcdf4.$(OBJEXT)
 EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES) $(NETCDF4_CODES)
 
@@ -58,7 +63,7 @@ else # classic-only build
 
 # Use the netCDF classic F90 code.
 libnetcdfm_la_SOURCES = netcdf.f90
-netcdf.$(OBJEXT): typesizes.mod
+netcdf.$(OBJEXT): typesizes.mod $(COMMON_CODES) $(NETCDF3_CODES)
 netcdf.mod: netcdf.$(OBJEXT)
 EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES)
 libnetcdff_la_SOURCES += netcdf3_file.f90
@@ -84,7 +89,6 @@ netcdf_f03.mod: module_netcdf_f03.$(OBJEXT)
 # Some mods are dependant on other mods in this dir.
 module_netcdf_nf_data.$(OBJEXT): netcdf_nc_data.mod
 module_netcdf_nc_interfaces.$(OBJEXT): netcdf_nc_data.mod
-module_netcdf4_nc_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
 module_netcdf_nf_interfaces.$(OBJEXT): netcdf_nf_data.mod
 module_netcdf_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod
 nf_nc.$(OBJEXT): netcdf_nc_interfaces.mod
@@ -116,6 +120,7 @@ if USE_NETCDF4
 
 # Add additional source files to the library to support netCDF4.
 libnetcdff_la_SOURCES += nf_lib.c nf_nc4.f90
+nf_nc4.$(OBJEXT): netcdf4_nc_interfaces.mod
 
 # Add these uninstalled convenience libraries for netcdf-4.
 noinst_LTLIBRARIES += libnetcdf4_nc_interfaces.la	\
@@ -132,7 +137,8 @@ netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.$(OBJEXT)
 netcdf4_f03.mod: module_netcdf4_f03.$(OBJEXT)
 
 # Some mods are dependant on other mods in this dir.
-module_netcdf4_nf_interfaces.$(OBJEXT): netcdf4_nc_interfaces.mod
+module_netcdf4_nf_interfaces.$(OBJEXT): netcdf4_nc_interfaces.mod netcdf_nf_data.mod 
+module_netcdf4_nc_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod 
 module_netcdf4_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod netcdf4_nf_interfaces.mod
 
 # Add the netcdf4 mod files to the list.
@@ -185,5 +191,3 @@ netcdf2.inc netcdf3.inc netcdf4.inc
 
 CLEANFILES = *.mod netcdf.inc
 
-# Turn off parallel builds in this directory.
-.NOTPARALLEL:


### PR DESCRIPTION
Getting the build dependencies right is about more than just enabling parallel builds.

Only if all the build dependencies are correct can we could on make building the correct files when we make a change. Since netcdf-fortran is somewhat complex, there are a lot of dependencies!

Part of #208 