### PR TITLE
Fix parallel builds

### DIFF
--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -45,9 +45,9 @@ nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90			\
 nf_logging.F90 nf_nc.f90
 
 # The respective objects depend on the netcdf_nc_interfaces module.
-￼nf_attio.lo nf_control.lo nf_dim.lo nf_genatt.lo nf_geninq.lo nf_genvar.lo    \
-￼nf_misc.lo nf_var1io.lo nf_varaio.lo nf_vario.lo nf_varmio.lo                 \
-￼nf_varsio.lo: $(netcdf_nc_interfaces_mod)
+nf_attio.lo nf_control.lo nf_dim.lo nf_genatt.lo nf_geninq.lo nf_genvar.lo    \
+nf_misc.lo nf_var1io.lo nf_varaio.lo nf_vario.lo nf_varmio.lo                 \
+nf_varsio.lo: netcdf_nc_interfaces.mod
 
 # Different source for the netcdf.mod is used for netcdf classic
 # vs. netcdf4.
@@ -55,17 +55,15 @@ if USE_NETCDF4
 
 # Use the netCDF-4 F90 code.
 libnetcdfm_la_SOURCES = netcdf4.f90
-netcdf4.$(OBJEXT): typesizes.mod $(COMMON_CODES) $(NETCDF4_CODES)
-netcdf.mod: netcdf4.$(OBJEXT)
-EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES) $(NETCDF4_CODES)
+netcdf4.lo: typesizes.mod $(COMMON_CODES) $(NETCDF4_CODES)
+netcdf.mod: netcdf4.lo
 
 else # classic-only build
 
 # Use the netCDF classic F90 code.
 libnetcdfm_la_SOURCES = netcdf.f90
-netcdf.$(OBJEXT): typesizes.mod $(COMMON_CODES) $(NETCDF3_CODES)
-netcdf.mod: netcdf.$(OBJEXT)
-EXTRA_libnetcdfm_la_DEPENDENCIES = $(COMMON_CODES)
+netcdf.lo: typesizes.mod $(COMMON_CODES) $(NETCDF3_CODES)
+netcdf.mod: netcdf.lo
 libnetcdff_la_SOURCES += netcdf3_file.f90
 
 endif # USE_NETCDF4
@@ -78,23 +76,22 @@ libnetcdf_nc_interfaces_la_SOURCES = module_netcdf_nc_interfaces.f90
 libnetcdf_nf_interfaces_la_SOURCES = module_netcdf_nf_interfaces.F90
 libnetcdf_f03_la_SOURCES = module_netcdf_f03.f90
 
-# Each mod file depends on the .o file.
-typesizes.mod: typeSizes.$(OBJEXT)
-netcdf_nc_data.mod: module_netcdf_nc_data.$(OBJEXT)
-netcdf_nf_data.mod: module_netcdf_nf_data.$(OBJEXT)
-netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.$(OBJEXT)
-netcdf_nf_interfaces.mod: module_netcdf_nf_interfaces.$(OBJEXT)
-netcdf_f03.mod: module_netcdf_f03.$(OBJEXT)
+# Each mod file depends on the .lo file.
+typesizes.mod: typeSizes.lo
+netcdf_nc_data.mod: module_netcdf_nc_data.lo
+netcdf_nf_data.mod: module_netcdf_nf_data.lo
+netcdf_nc_interfaces.mod: module_netcdf_nc_interfaces.lo
+netcdf_nf_interfaces.mod: module_netcdf_nf_interfaces.lo
+netcdf_f03.mod: module_netcdf_f03.lo
 
 # Some mods are dependant on other mods in this dir.
-module_netcdf_nf_data.$(OBJEXT): netcdf_nc_data.mod
-module_netcdf_nc_interfaces.$(OBJEXT): netcdf_nc_data.mod
-module_netcdf_nf_interfaces.$(OBJEXT): netcdf_nf_data.mod
-module_netcdf_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod
-nf_nc.$(OBJEXT): netcdf_nc_interfaces.mod
+module_netcdf_nf_data.lo: netcdf_nc_data.mod
+module_netcdf_nc_interfaces.lo: netcdf_nc_data.mod
+module_netcdf_nf_interfaces.lo: netcdf_nf_data.mod
+module_netcdf_f03.lo: netcdf_nf_data.mod netcdf_nf_interfaces.mod
+nf_nc.lo: netcdf_nc_interfaces.mod
 
-# Mod files are built and then installed as headers. Order is
-# significant in this list of modfiles.
+# Mod files are built and then installed as headers.
 MODFILES = typesizes.mod netcdf_nc_data.mod netcdf_nf_data.mod	\
 netcdf_nc_interfaces.mod netcdf_nf_interfaces.mod
 
@@ -107,9 +104,9 @@ libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
 if BUILD_V2
 noinst_LTLIBRARIES += libnetcdf_fortv2_c_interfaces.la
 libnetcdf_fortv2_c_interfaces_la_SOURCES = module_netcdf_fortv2_c_interfaces.f90
-netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.$(OBJEXT)
-module_netcdf_fortv2_c_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod
-nf_fortv2.$(OBJEXT): $(netcdf_fortv2_c_interfaces_mod) $(netcdf_nc_interfaces_mod)
+netcdf_fortv2_c_interfaces.mod: module_netcdf_fortv2_c_interfaces.lo
+module_netcdf_fortv2_c_interfaces.lo: netcdf_nc_interfaces.mod
+nf_fortv2.lo: netcdf_fortv2_c_interfaces.mod netcdf_nc_interfaces.mod
 MODFILES += netcdf_fortv2_c_interfaces.mod
 libnetcdff_la_SOURCES += nf_v2compat.c nf_fortv2.f90
 libnetcdff_la_LIBADD += libnetcdf_fortv2_c_interfaces.la
@@ -131,15 +128,15 @@ libnetcdf4_nc_interfaces_la_SOURCES = module_netcdf4_nc_interfaces.f90
 libnetcdf4_nf_interfaces_la_SOURCES = module_netcdf4_nf_interfaces.F90
 libnetcdf4_f03_la_SOURCES = module_netcdf4_f03.f90
 
-# Each mod file depends on the .o file.
-netcdf4_nc_interfaces.mod: module_netcdf4_nc_interfaces.$(OBJEXT)
-netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.$(OBJEXT)
-netcdf4_f03.mod: module_netcdf4_f03.$(OBJEXT)
+# Each mod file depends on the .lo file.
+netcdf4_nc_interfaces.mod: module_netcdf4_nc_interfaces.lo
+netcdf4_nf_interfaces.mod: module_netcdf4_nf_interfaces.lo
+netcdf4_f03.mod: module_netcdf4_f03.lo
 
 # Some mods are dependant on other mods in this dir.
-module_netcdf4_nf_interfaces.$(OBJEXT): netcdf4_nc_interfaces.mod netcdf_nf_data.mod 
-module_netcdf4_nc_interfaces.$(OBJEXT): netcdf_nc_interfaces.mod 
-module_netcdf4_f03.$(OBJEXT): netcdf_nf_data.mod netcdf_nf_interfaces.mod netcdf4_nf_interfaces.mod
+module_netcdf4_nf_interfaces.lo: netcdf4_nc_interfaces.mod netcdf_nf_data.mod
+module_netcdf4_nc_interfaces.lo: netcdf_nc_interfaces.mod
+module_netcdf4_f03.lo: netcdf_nf_data.mod netcdf_nf_interfaces.mod netcdf4_nf_interfaces.mod
 
 # Add the netcdf4 mod files to the list.
 MODFILES += netcdf4_nc_interfaces.mod netcdf4_nf_interfaces.mod	\
@@ -186,7 +183,7 @@ if USE_LOGGING
 	echo '      external nf_set_log_level' >> netcdf.inc
 endif
 
-EXTRA_DIST = $(COMMON_CODES) $(NETCDF4_CODES) CMakeLists.txt	\
+EXTRA_DIST = $(COMMON_CODES) $(NETCDF4_CODES) $(NETCDF3_CODES) CMakeLists.txt	\
 netcdf2.inc netcdf3.inc netcdf4.inc
 
 CLEANFILES = *.mod netcdf.inc

--- a/nf_test/Makefile.am
+++ b/nf_test/Makefile.am
@@ -69,6 +69,10 @@ nf03_error.F nf03_test.F test03_read.F test03_write.F util03.F		\
 f03lib.c
 nf03_test_LDADD = libtests.la ${top_builddir}/fortran/libnetcdff.la
 
+test03_get.$(OBJEXT) test03_put.$(OBJEXT) nf03_error.$(OBJEXT)          \
+nf03_test.$(OBJEXT) test03_read.$(OBJEXT) test03_write.$(OBJEXT)        \
+util03.$(OBJEXT): tests.mod
+
 # If the V2 API is being built, then make copies of the two V2 F77 API
 # tests, modified to use the fortran module.
 if BUILD_V2
@@ -78,6 +82,7 @@ f03test_SOURCES = f03test.F
 f03test_LDADD = libtests.la ${top_builddir}/fortran/libnetcdff.la
 tst03_f77_v2_SOURCES = tst03_f77_v2.F
 tst03_f77_v2_LDADD = libtests.la ${top_builddir}/fortran/libnetcdff.la
+tst03_f77_v2.$(OBJEXT): tests.mod
 endif # BUILD_V2
 
 # Note that all these fortran programs are built at compile-time on


### PR DESCRIPTION
In contrast to #221, this PR fixes parallel builds only:

1. `$(NETCDF3_CODES)` should be listed in `EXTRA_DIST`.
2. Some rules that have been copied from #221 mention unset variables, e.g. `$(netcdf_nc_interfaces_mod)`.
3. Added dependencies on `tests.mod` in `nf_test`.
4. If an object file is part of a libtool library, the dependencies on Fortran module files should mention `.lo` files and not `.$(OBJEXT)` files because `.$(OBJEXT)` files are not part of the dependency graph of the library according to `make`. This is, however, not the case for objects that get linked into an executable directly, which is why new dependencies in `nf_test` mention `.$(OBJEXT)` files.

I would also suggest the following improvements to the Makefiles:
1. Fortran module files should not be listed in `BUILT_SOURCES` because this triggers compilation even when it is not needed, e.g. `configure ... && make dist`.
2. `netcdf.inc` does not have to be listed in `BUILT_SOURCES` because it is already listed in `nodist_include_HEADERS`, which is enough to trigger its generation when needed.
3. It is not always easy to identify which Fortran module files need to be installed, which is why developers often simply install all generated module files. This, however, does not seem to be the case for `netcdf-fortran`: the only module file that needs to be installed is `netcdf.mod`. Otherwise, if I missed something or it has been decided that all generated Fortran module files must be installed, it might make sense not to make an exception for `netcdf_f03.mod`.
4. There is a [convention](https://www.gnu.org/software/automake/manual/html_node/Clean.html) on how `clean` rules should be implemented. According to it, Fortran module files should be listed in `MOSTLYCLEANFILES` but not in `CLEANFILES`.
5. Currently, if a Fortran module file is accidentally deleted, `make` does not know how to create it because the respective object file is still there. For that reason, #221 introduced special rules: [#1](https://github.com/skosukhin/netcdf-fortran/blob/a4c2e7e40c4035640f3076691cf57d035e826d6b/fortran/Makefile.am#L160-L172) and [#2](https://github.com/skosukhin/netcdf-fortran/blob/a4c2e7e40c4035640f3076691cf57d035e826d6b/nf_test/Makefile.am#L54-L55).
6. File `nf_logging.F90` should be added to the list of source files only if logging is enabled. Otherwise, there is an empty object file in the library, which is a bit messy and often reported as a warning by some linkers. Additionally, some Fortran compilers, e.g. NAG, refuse to compile empty source files, which fails the building.
7. `fortran/Makefile.am` declares a lot of convenience libraries. Even if we forget about the problems reported in #221, it leads to an overhead at build time: additional calls to `libtool`, `ar`, etc. Additionally, it makes the makefile less readable. At least for me. I would be very grateful if anybody explained to me the reason for using them. Thank you.