### PR TITLE
commented out cache value test because it doesnt work on parallel

### DIFF
--- a/nf03_test4/f90tst_vars2.f90
+++ b/nf03_test4/f90tst_vars2.f90
@@ -111,8 +111,14 @@ program f90tst_vars2
   if (chunksizes_in(1) /= chunksizes(1) .or. chunksizes_in(2) /= chunksizes(2)) &
        stop 4
   if (endianness_in .ne. nf90_endian_big) stop 5
-  if (cache_size_in .ne. 16 .or. cache_nelems_in .ne. 4133 .or. &
-       cache_preemption .ne. CACHE_PREEMPTION) stop 555
+
+  ! This test code commented out because it fails parallel builds,
+  ! which don't use the cache, so don't get the same size
+  ! settings. Since we are not (yet) using a preprocessor on the
+  ! fortran code, there's no way to ifdef out these tests.
+  ! print *, cache_size_in, cache_nelems_in, cache_preemption
+  ! if (cache_size_in .ne. 16 .or. cache_nelems_in .ne. 4133 .or. &
+  !      cache_preemption .ne. CACHE_PREEMPTION) stop 555
 
   ! Check variable 2.
   call check(nf90_inquire_variable(ncid, varid2_in, name_in, xtype_in, ndims_in, dimids_in, &


### PR DESCRIPTION
Fixes #253 

This comments out some test code which tests cache values. THese values are not set in paralell builds, so the test fails for parallel builds.

Since we don't do preprocessing, there's no easy way to ifdef..


