### PR TITLE
Change error message to mention LIBS and static builds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,8 +14,8 @@ Entries are in reverse chronological order (most recent first).
 
 ### Changes
 
-* Added support for HDF5 compact storage. See [Github #213](https://github.com/Unidata/netcdf-fortran/issues/207).
-* Added support for creating netCDF/HDF5 files with szip compression with new functions nf90_def_var_szip() and nf_def_var_szip(). See [Github #213](https://github.com/Unidata/netcdf-fortran/issues/213).
+* Added support for HDF5 compact storage in F77 API. See [Github #213](https://github.com/Unidata/netcdf-fortran/issues/207).
+* Added support for creating netCDF/HDF5 files with szip compression with new functions nf90_def_var_szip() and nf_def_var_szip(). See [Github #213](https://github.com/Unidata/netcdf-fortran/issues/213), [Github #251](https://github.com/Unidata/netcdf-fortran/issues/251).
 * Corrected an issue where parallel netCDF-Fortran builds would fail despite the presense of MPI libraries/compiler/infrastructure. See [Github #208](https://github.com/Unidata/netcdf-fortran/issues/208) for more information.
 
 ## 4.5.2 - September 18, 2019

--- a/configure.ac
+++ b/configure.ac
@@ -89,8 +89,6 @@ if test "x$nc_has_parallel4" = xyes; then
 fi
 AC_MSG_RESULT([$nc_has_parallel4])
 
-# Starting with version 4.7.4, netcdf-c has function nc_def_var_szip().
-AC_SEARCH_LIBS([nc_def_var_szip], [netcdf], [], [AC_MSG_ERROR([netcdf-c version 4.7.4 or greater is required])])
 AC_MSG_CHECKING([if netCDF was built with support for szip writes])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 #include <netcdf_meta.h>
@@ -402,10 +400,16 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [], [])
 
 # Find the netCDF header and library.
 AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([netcdf.h could not be found. Please set CPPFLAGS.])])
-AC_SEARCH_LIBS([nc_open], [netcdf], [], [AC_MSG_ERROR([Could not link to netcdf C library. Please set LDFLAGS.])])
+AC_SEARCH_LIBS([nc_open], [netcdf], [],
+			  [AC_MSG_ERROR([Could not link to netcdf C library. Please set LDFLAGS; for static builds set LIBS to the results of nc-config --libs.])])
 
 # See if various functions are available
-AC_CHECK_FUNCS([nc_def_opaque nccreate nc_set_log_level oc_open])
+AC_CHECK_FUNCS([nc_def_opaque nccreate nc_set_log_level oc_open nc_def_var_szip])
+
+# Starting with version 4.7.4, netcdf-c has function nc_def_var_szip().
+if test "x$ac_cv_func_nc_def_var_szip" != xyes; then
+   AC_MSG_ERROR([netcdf-c version 4.7.4 or greater is required])
+fi
 
 nc_build_v2=no
 nc_build_v4=no


### PR DESCRIPTION
Fixes #251 

The answer is that the user must set LIBS to `nc-config --libs` for static building. I have changed the error message to remind them to do so.

Also I changed the way nc_def_var_szip was found, so that it is checked for after all the compiler stuff has been checked.

Thanks to @GeorgeVandenberghe-NOAA for helping track this down.