### PR TITLE
Added missing nf90_inq_format() function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,9 @@ Entries are in reverse chronological order (most recent first).
 
 * netCDF-C: 4.7.4+
 
+### Changes
+* Added nf90_inq_format to the F90 API. See [Github #263](https://github.com/Unidata/netcdf-fortran/issues/263).
+
 ## 4.5.3 - June 2, 2020
 
 ### Requirements

--- a/fortran/netcdf_file.f90
+++ b/fortran/netcdf_file.f90
@@ -155,6 +155,7 @@ end function nf90_inq_path
 function nf90_inq_format(ncid, format_type)
   integer,            intent(in)    :: ncid
   integer,            intent(out)   :: format_type
+  integer                           :: nf90_inq_format
 
   nf90_inq_format = nf_inq_format(ncid, format_type)
 

--- a/fortran/netcdf_file.f90
+++ b/fortran/netcdf_file.f90
@@ -4,7 +4,7 @@
 ! This file contains the netcdf file functions that are shared by
 ! netcdf-3 and netcdf-4.
 
-! $Id: netcdf4_constants.f90,v 1.14 2010/05/25 13:53:00 ed Exp $
+! Ed Hartnett, 2010
 ! -------
 function nf90_inq_libvers()
   character(len = 80) :: nf90_inq_libvers
@@ -142,7 +142,6 @@ function nf90_inquire(ncid, nDimensions, nVariables, nAttributes, unlimitedDimId
 end function nf90_inquire
 
 function nf90_inq_path(ncid, pathlen, path)
-
   integer,            intent(in)    :: ncid
   integer,            intent(inout) :: pathlen
   character(len = *), intent(inout) :: path
@@ -152,4 +151,12 @@ function nf90_inq_path(ncid, pathlen, path)
   nf90_inq_path = nf_inq_path(ncid, pathlen, path)
 
 end function nf90_inq_path
+
+function nf90_inq_format(ncid, format_type)
+  integer,            intent(in)    :: ncid
+  integer,            intent(out)   :: format_type
+
+  nf90_inq_format = nf_inq_format(ncid, format_type)
+
+end function nf90_inq_format
 

--- a/fortran/netcdf_visibility.f90
+++ b/fortran/netcdf_visibility.f90
@@ -8,7 +8,7 @@
             nf90_sync, nf90_abort, nf90_close, nf90_delete
             
   ! File level inquiry
-  public :: nf90_inquire, nf90_inq_path
+  public :: nf90_inquire, nf90_inq_path, nf90_inq_format
   
   ! Dimension routines
   public :: nf90_def_dim, nf90_inq_dimid, nf90_rename_dim, nf90_inquire_dimension

--- a/nf03_test/tst_f90.f90
+++ b/nf03_test/tst_f90.f90
@@ -18,6 +18,7 @@ program netcdfTest
   integer, parameter :: numLats = 4, numLons = 3, &
                         numFrTimes = 2, timeStringLen = 20, mxStrLen=80
   character (len = *), parameter :: fileName = "tst_f90.nc"
+  integer :: fmt
   integer :: counter, i
   real, dimension(numLons, numLats, numFrTimes) :: pressure
   integer (kind = FourByteInt), dimension(numFrTimes) :: frTimeVals
@@ -39,6 +40,10 @@ program netcdfTest
     
   ! Create the file
   call check(nf90_create(path = trim(fileName), cmode = nf90_clobber, ncid = ncFileID))
+
+  ! Check the format.
+  call check(nf90_inq_format(ncFileID, fmt))
+  if (fmt .ne. nf90_format_classic) stop 2
   
   ! Define the dimensions
   call check(nf90_def_dim(ncid = ncFileID, name = "lat",     len = numLats,        dimid = latDimID))

--- a/nf03_test/tst_f90.f90
+++ b/nf03_test/tst_f90.f90
@@ -1,7 +1,10 @@
-! This program provides an elementary check of some of the parts of the 
-!   Fortran 90 interface to netCDF 3.5. It is a Fortran 90 implementation
-!   of the nctst.cpp program provided with the C++ interface to netcdf
-!   (in the src/cxx directory of the netcdf distribution). 
+! This program provides an elementary check of some of the parts of
+! the Fortran 90 interface to netCDF 3.5. It is a Fortran 90
+! implementation of the nctst.cpp program provided with the C++
+! interface to netcdf (in the src/cxx directory of the netcdf
+! distribution).
+!
+! Russ Rew
 !
 program netcdfTest
   use typeSizes

--- a/nf03_test4/f90tst_nc4.f90
+++ b/nf03_test4/f90tst_nc4.f90
@@ -10,19 +10,23 @@ program f90tst_nc4
   use typeSizes
   use netcdf
   implicit none
-  integer :: fh, dimid, varid, ndim, nvar
+  integer :: fh, dimid, varid, ndim, nvar, fmt
   character (len = *), parameter :: FILE_NAME = "f90tst_nc4.nc"
 
   print *, ''
   print *,'*** testing simple netCDF-4 file.'
 
   call check(nf90_create(FILE_NAME, NF90_NETCDF4, fh))
+  call check(nf90_inq_format(fh, fmt))
+  if (fmt .ne. nf90_format_netcdf4) stop 4
   call check(nf90_def_dim(fh, 'fred', 10, dimid))
   call check(nf90_def_var(fh, 'john', NF90_INT, (/dimid/), varid))
   call check(nf90_close(fh))
   
   ! Check the file.
   call check(nf90_open(FILE_NAME, NF90_WRITE, fh))
+  call check(nf90_inq_format(fh, fmt))
+  if (fmt .ne. nf90_format_netcdf4) stop 5
   call check(nf90_inquire(fh, nDimensions = ndim, nVariables = nvar))
   if (nvar .ne. 1 .or. ndim .ne. 1) stop 3
   call check(nf90_close(fh))
@@ -31,12 +35,16 @@ program f90tst_nc4
   print *,'*** Testing simple classic file.'
 
   call check(nf90_create(FILE_NAME, NF90_CLOBBER, fh))
+  call check(nf90_inq_format(fh, fmt))
+  if (fmt .ne. nf90_format_classic) stop 6
   call check(nf90_def_dim(fh, 'fred', 10, dimid))
   call check(nf90_def_var(fh, 'john', NF90_INT, (/dimid/), varid))
   call check(nf90_close(fh))
   
   ! Check the file.
   call check(nf90_open(FILE_NAME, NF90_WRITE, fh))
+  call check(nf90_inq_format(fh, fmt))
+  if (fmt .ne. nf90_format_classic) stop 6
   call check(nf90_inquire(fh, nDimensions = ndim, nVariables = nvar))
   if (nvar .ne. 1 .or. ndim .ne. 1) stop 3
   call check(nf90_close(fh))


### PR DESCRIPTION
While doing some work on the GFDL FMS package, which uses the netCDF F90 API, I realized that the nf90_inq_foramt() function is missing, though the nf_inq_format() function is present in the F77 API, and all the appropriate constants are already defined in netcdf_constents.f90.

In this PR I add nf90_inq_format() and a test for classic and netCDF-4 builds.

Part of #263