### PR TITLE
Fix for nf-config using autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -590,7 +590,7 @@ xsolaris*)
 *);;
 esac
 
-NC_FLIBS="-lnetcdff $NC_FLIBS"
+NC_FLIBS="-lnetcdff $NC_LIBS"
 
 AC_SUBST([enable_shared])
 AC_SUBST([enable_static])


### PR DESCRIPTION
This PR is to restore the previous functionality of `nf-config` as detailed in https://github.com/Unidata/netcdf-fortran/issues/270.

Currently, building netcdf-fortran with autotools results in `nf-config` that returns:
```
-L/Users/mathomp4/NetcdfFortranFix/before/lib 
-lnetcdff
```
where you only get out the `libnetcdff` link, but not everything you need to link to netcdf-fortran.

Before https://github.com/Unidata/netcdf-fortran/commit/82273f82f5f20ed5e2e64d847476dfc48b8f33ff, `nf-config --flibs` returned something like:
```
-L/Users/mathomp4/NetcdfFortranFix/after/lib 
-lnetcdff -lnetcdf -lm 
-L/Users/mathomp4/NetcdfFortranFix/after/lib 
-L/Users/mathomp4/NetcdfFortranFix/after/lib 
-lnetcdf -ljpeg -lmfhdf -ldf -ljpeg -lhdf5_hl -lhdf5 -lm -lz 
-L/Users/mathomp4/NetcdfFortranFix/after/lib 
-lsz -ljpeg -ldl -lm
```
(which is what I get with this PR). This is essentially what you get from `nc-config --libs` appended to what's needed from netcdf-fortran