### PR TITLE
Tweak Travis-CI Settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ services:
 
 env:
     matrix:
-        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DCMAKE_C_FLAGS=-fsigned-char' CURHOST=docker-nc3-gcc-x64-signed
-        - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DCMAKE_C_FLAGS=-fsigned-char' CURHOST=docker-nc3-gcc-x86-signed
+        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DENABLE_HDF4=OFF -DCMAKE_C_FLAGS=-fsigned-char' AC_COPTS='--disable-netcdf4 --disable-hdf4' CURHOST=docker-nc3-gcc-x64-signed
+        - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DENABLE_HDF4=OFF -DCMAKE_C_FLAGS=-fsigned-char' AC_COPTS='--disable-netcdf4 --disable-hdf4' CURHOST=docker-nc3-gcc-x86-signed
 
-        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DCMAKE_C_FLAGS=-funsigned-char' CURHOST=docker-nc3-gcc-x64-unsigned
-        - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DCMAKE_C_FLAGS=-funsigned-char' CURHOST=docker-nc3-gcc-x86-unsigned
+        - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DENABLE_HDF4=OFF -DCMAKE_C_FLAGS=-funsigned-char' AC_COPTS='--disable-netcdf4 --disable-hdf4' CURHOST=docker-nc3-gcc-x64-unsigned
+        - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DENABLE_NETCDF4=OFF -DENABLE_HDF4=OFF -DCMAKE_C_FLAGS=-funsigned-char' AC_COPTS='--disable-netcdf4 --disable-hdf4' CURHOST=docker-nc3-gcc-x86-unsigned
 
         - DOCKIMG=unidata/nctests:serial   USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DCMAKE_C_FLAGS=-fsigned-char' CURHOST=docker-nc4-gcc-x64-signed
         - DOCKIMG=unidata/nctests:serial32 USECMAKE=TRUE USEAC=TRUE DISTCHECK=TRUE USE_CC=gcc   COPTS='-DCMAKE_C_FLAGS=-fsigned-char' CURHOST=docker-nc4-gcc-x86-signed

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(netcdff_SOURCES
 # Check if netcdf-c has parallel I/O functions
 check_symbol_exists(nc_create_par "netcdf.h" HAVE_PARALLEL)
 message (STATUS "found netcdf-c parallel support: ${HAVE_PARALLEL}")
-IF (${USE_NETCDF4}
+IF (${USE_NETCDF4})
 IF(HAVE_PARALLEL)
   SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc.f90)
   message (STATUS "including netcdf-f parallel support")

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -15,12 +15,14 @@ SET(netcdff_SOURCES
 # Check if netcdf-c has parallel I/O functions
 check_symbol_exists(nc_create_par "netcdf.h" HAVE_PARALLEL)
 message (STATUS "found netcdf-c parallel support: ${HAVE_PARALLEL}")
-IF (USE_NETCDF4 AND HAVE_PARALLEL)
+IF (${USE_NETCDF4}
+IF(HAVE_PARALLEL)
   SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc.f90)
   message (STATUS "including netcdf-f parallel support")
 ELSE ()
   SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc_noparallel.f90)
   message (STATUS "no netcdf-f parallel support")
+ENDIF(HAVE_PARALLEL)
 ENDIF(${USE_NETCDF4} AND HAVE_PARALLEL)
 
 IF (USE_NETCDF4)

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(netcdff_SOURCES
 # Check if netcdf-c has parallel I/O functions
 check_symbol_exists(nc_create_par "netcdf.h" HAVE_PARALLEL)
 message (STATUS "found netcdf-c parallel support: ${HAVE_PARALLEL}")
-IF (${USE_NETCDF4} AND HAVE_PARALLEL)
+IF (USE_NETCDF4 AND HAVE_PARALLEL)
   SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc.f90)
   message (STATUS "including netcdf-f parallel support")
 ELSE ()


### PR DESCRIPTION
Disable hdf4 tests when compiling netcdf-c without hdf5 support.  See https://github.com/Unidata/netcdf-c/issues/1402 for more information.