### PR TITLE
Attempt to correct an issue being observed under linux and OSX with gfortran

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -312,6 +312,7 @@ fi
 # See https://github.com/Unidata/netcdf-fortran/issues/212
 # See https://github.com/Unidata/netcdf-fortran/issues/218
 ac_save_FCFLAGS="$FCFLAGS"
+ac_save_FFLAGS="$FFLAGS"
 AC_MSG_CHECKING([if Fortran compiler supports allow-mismatch flag])
 cat <<EOF >conftest.f90
 Program test
@@ -322,7 +323,8 @@ doit='$FC -c ${FCFLAGS} ${FCFLAGS_f90} -fallow-argument-mismatch conftest.f90'
 if AC_TRY_EVAL(doit); then
    nf_allow_mismatch=yes
    FCFLAGS="${FCFLAGS} -fallow-argument-mismatch"
-  else
+   FFLAGS="${FFLAGS} -fallow-argument-mismatch"
+else
    nf_allow_mismatch=no
 fi
 AC_MSG_RESULT([$nf_allow_mismatch])
@@ -338,7 +340,8 @@ doit='$FC -c ${FCFLAGS} ${FCFLAGS_f90} -mismatch_all conftest.f90'
 if AC_TRY_EVAL(doit); then
    nf_mismatch_all=yes
    FCFLAGS="${FCFLAGS} -mismatch_all"
-  else
+   FFLAGS="${FFLAGS} -mismatch_all"
+else
    nf_mismatch_all=no
 fi
 AC_MSG_RESULT([$nf_mismatch_all])


### PR DESCRIPTION
Adding `-fallow-argument-mismatch` to `FFLAGS` as adding it to `FCFLAGS` was still resulting in failures when running `make check` on linux and OSX.