### PR TITLE
Rationalize CMake minimum version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ SET (LIB_TYPE STATIC)
 IF (BUILD_SHARED_LIBS)
   SET(LIB_TYPE SHARED)
   IF(CMAKE_COMPILER_IS_GNUCC OR APPLE)
-    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+    string(APPEND CMAKE_C_FLAGS " -fPIC")
   ENDIF()
 ENDIF()
 
@@ -179,11 +179,11 @@ ENDIF()
 #
 # Also, set some other default compiler flags.
 IF(CMAKE_COMPILER_IS_GNUCC OR APPLE)
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wno-unused-variable -Wno-unused-parameter")
+  string(APPEND CMAKE_C_FLAGS " -g -Wall -Wno-unused-variable -Wno-unused-parameter")
 ENDIF()
 
 IF(NOT ENABLE_COVERAGE_TESTS)
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+  string(APPEND CMAKE_C_FLAGS " -O2")
 ENDIF()
 
 
@@ -209,9 +209,9 @@ ENDIF()
 SET(EXTRA_DIST "")
 MACRO(ADD_EXTRA_DIST files)
   FOREACH(F ${files})
-    SET(EXTRA_DIST ${EXTRA_DIST} ${CMAKE_CURRENT_SOURCE_DIR}/${F})
-    SET(EXTRA_DIST ${EXTRA_DIST} PARENT_SCOPE)
+    list(APPEND EXTRA_DIST ${CMAKE_CURRENT_SOURCE_DIR}/${F})
   ENDFOREACH()
+  SET(EXTRA_DIST ${EXTRA_DIST} PARENT_SCOPE)
 ENDMACRO()
 
 # A basic script used to convert m4 files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,14 @@
 ##################################
 
 #Minimum required CMake Version
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 #Project Name for netCDF-Fortran
-PROJECT (NC4F Fortran C)
+PROJECT (NC4F
+LANGUAGES C Fortran
+HOMEPAGE_URL "https://www.unidata.ucar.edu/software/netcdf/docs-fortran/"
+DESCRIPTION "NetCDF is a set of software libraries and machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data."
+)
 SET(NC4F_CTEST_PROJECT_NAME "netcdf-fortran")
 
 set(PACKAGE "${NC4F_CTEST_PROJECT_NAME}" CACHE STRING "")


### PR DESCRIPTION
As with https://github.com/Unidata/netcdf-c/pull/2218, older versions of CMake than 3.12
are already broken with NetCDF and uncommon nowadays.
It may be better to explicitly require 3.12 or newer.

This also suppresses several nuisance warnings about unexpected behavior when using a modern CMake version.