### PR TITLE
set 'CMAKE_POSITION_INDEPENDENT_CODE ON' for shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,9 +169,7 @@ OPTION(BUILD_SHARED_LIBS "Configure netCDF as a shared library." ON)
 SET (LIB_TYPE STATIC)
 IF (BUILD_SHARED_LIBS)
   SET(LIB_TYPE SHARED)
-  IF(CMAKE_COMPILER_IS_GNUCC OR APPLE)
-    string(APPEND CMAKE_C_FLAGS " -fPIC")
-  ENDIF()
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 ENDIF()
 
 # Supress unused variable and parameter warnings, for the time being,

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -138,9 +138,7 @@ OPTION(BUILD_SHARED_LIBS "Configure netCDF as a shared library." ON)
 SET (LIB_TYPE STATIC)
 IF (BUILD_SHARED_LIBS)
   SET(LIB_TYPE SHARED)
-  IF(CMAKE_COMPILER_IS_GNUCC)
-    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  ENDIF()
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 ENDIF()
 
 # This is what we are building: a convenience library of Fortran 2003 functions.


### PR DESCRIPTION
Solving: https://github.com/geospace-code/nc4fortran/issues/4

`-fPIC` was only set for APPLE or when using GNUCC compiler. In my case I ran into a linker error with Intel oneAPI on Ubuntu.

I don't know if setting `CMAKE_POSITION_INDEPENDENT_CODE ON` is to much, since I guess it will also affect the fortran tragets, so we could also only set the `POSITION_INDEPENDENT_CODE` property for the `netcdff_c` target.

This could also solve https://github.com/Unidata/netcdf-fortran/issues/35