### PR TITLE
add parallel I/O builds and tests to the CI, and add hdf5-1.12.1 testing

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.8 ]
+        hdf5: [ 1.10.8, 1.12.1 ]
         netcdf: [ v4.7.4, v4.8.1, main ]
 
     steps:
@@ -70,7 +70,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.8 ]
+        hdf5: [ 1.10.8, 1.12.1 ]
         netcdf: [ v4.7.4, v4.8.1, main ]
 
     steps:
@@ -128,7 +128,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.8 ]
+        hdf5: [ 1.10.8, 1.12.1 ]
         netcdf: [ v4.7.4, v4.8.1, main ]
 
     steps:
@@ -209,7 +209,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.8 ]
+        hdf5: [ 1.10.8, 1.12.1 ]
         netcdf: [ v4.7.4, v4.8.1, main ]
 
     steps:
@@ -292,7 +292,7 @@ jobs:
 
     strategy:
       matrix:
-        hdf5: [ 1.10.8 ]
+        hdf5: [ 1.10.8, 1.12.1 ]
         netcdf: [ v4.7.4, v4.8.1, main ]
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -64,6 +64,62 @@ jobs:
           popd
 
 
+  build-deps-parallel:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        hdf5: [ 1.10.8 ]
+        netcdf: [ v4.7.4, v4.8.1, main ]
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Install System dependencies
+        shell: bash -l {0}
+        run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev gfortran mpich libmpich-dev
+
+        ###
+        # Set Environmental Variables
+        ###
+      - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/include" >> $GITHUB_ENV
+      - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
+
+        ###
+        # Installing libhdf4 and libhdf5
+        ###
+      - name: Cache libhdf5-${{ matrix.hdf5 }}-${{ matrix.netcdf }}_par
+        id: cache-hdf5_par
+        uses: actions/cache@v2
+        with:
+          path: ~/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}
+          key: hdf5-${{ runner.os }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}_par
+
+
+      - name: Build libhdf5-${{ matrix.hdf5 }}-${{ matrix.netcdf }}_par
+        if: steps.cache-hdf5_par.outputs.cache-hit != 'true'
+        run: |
+          pushd $HOME
+          wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(echo ${{ matrix.hdf5 }} | cut -d. -f 1,2)/hdf5-${{ matrix.hdf5 }}/src/hdf5-${{ matrix.hdf5 }}.tar.bz2
+          tar -jxf hdf5-${{ matrix.hdf5 }}.tar.bz2
+          pushd hdf5-${{ matrix.hdf5 }}
+          CC=mpicc ./configure --disable-static --enable-shared --prefix=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }} --enable-hl --with-szlib --enable-parallel
+          make -j
+          make install -j
+          popd
+          git clone -b ${{ matrix.netcdf}} https://github.com/Unidata/netcdf-c
+          pushd netcdf-c
+          autoreconf -if
+          CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --disable-static --enable-shared --prefix=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}
+          make -j
+          make install -j
+          popd
+          popd
+
+
   nf-autotools:
 
     needs: build-deps
@@ -144,6 +200,89 @@ jobs:
       #- name: Make Distcheck
       #  shell: bash -l {0}
       #  run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make distcheck -j
+      
+  nf-autotools_par:
+
+    needs: build-deps-parallel
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        hdf5: [ 1.10.8 ]
+        netcdf: [ v4.7.4, v4.8.1, main ]
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Install System dependencies
+        shell: bash -l {0}
+        run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev  mpich libmpich-dev
+
+###
+# Set Environmental Variables
+###
+
+      - run: echo "CC=mpicc" >> $GITHUB_ENV
+      - run: echo "FC=mpifort" >> $GITHUB_ENV
+      - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/include" >> $GITHUB_ENV
+      - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
+      - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
+
+###
+# Fetch Cache
+###
+
+      - name: Fetch HDF Cache
+        id: cache-hdf
+        uses: actions/cache@v2
+        with:
+          path: ~/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}
+          key: hdf5-${{ runner.os }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}_par
+
+      - name: Check Cache
+        shell: bash -l {0}
+        run: ls ${HOME}/environments && ls ${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }} && ls ${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf}}/lib
+
+###
+# Configure and build
+###
+
+      - name: Run autoconf
+        shell: bash -l {0}
+        run: autoreconf -if
+
+      - name: Configure
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} CC=${CC} ./configure --enable-parallel-tests
+
+      - name: Look at config.log if error
+        shell: bash -l {0}
+        run: cat config.log
+        if: ${{ failure() }}
+
+      - name: Print Summary
+        shell: bash -l {0}
+        run: cat libnetcdff.settings
+
+      - name: Build Library and Utilities
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} CC=${CC} FC=${FC} make -j
+        if: ${{ success() }}
+
+      - name: Build Tests
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} CC=${CC} FC=${FC} make check TESTS="" -j
+        if: ${{ success() }}
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} CC=${CC} FC=${FC} make check -j
+        if: ${{ success() }}
+
+      #- name: Make Distcheck
+      #  shell: bash -l {0}
+      #  run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} CC=${CC} FC=${FC} make distcheck -j
 
   nf-cmake:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -84,6 +84,7 @@ jobs:
         ###
         # Set Environmental Variables
         ###
+      - run: echo "CC=mpicc >> $GITHUB_ENV
       - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/include" >> $GITHUB_ENV
       - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
@@ -106,14 +107,14 @@ jobs:
           wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(echo ${{ matrix.hdf5 }} | cut -d. -f 1,2)/hdf5-${{ matrix.hdf5 }}/src/hdf5-${{ matrix.hdf5 }}.tar.bz2
           tar -jxf hdf5-${{ matrix.hdf5 }}.tar.bz2
           pushd hdf5-${{ matrix.hdf5 }}
-          CC=mpicc ./configure --disable-static --enable-shared --prefix=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }} --enable-hl --with-szlib --enable-parallel
+          ./configure --disable-static --enable-shared --prefix=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }} --enable-hl --with-szlib --enable-parallel
           make -j
           make install -j
           popd
           git clone -b ${{ matrix.netcdf}} https://github.com/Unidata/netcdf-c
           pushd netcdf-c
           autoreconf -if
-          CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --disable-static --enable-shared --prefix=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}
+          CC=${CC} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --disable-static --enable-shared --prefix=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}
           make -j
           make install -j
           popd

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -84,7 +84,7 @@ jobs:
         ###
         # Set Environmental Variables
         ###
-      - run: echo "CC=mpicc >> $GITHUB_ENV
+      - run: echo "CC=mpicc" >> $GITHUB_ENV
       - run: echo "CFLAGS=-I${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/include" >> $GITHUB_ENV
       - run: echo "LDFLAGS=-L${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV
       - run: echo "LD_LIBRARY_PATH=${HOME}/environments/${{ matrix.hdf5 }}-${{ matrix.netcdf }}/lib" >> $GITHUB_ENV

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #                                               -*- Autoconf -*-
-# This is part of Unidata's netCDF package. Copyright 2011-2019, see
+# This is part of Unidata's netCDF package. Copyright 2011-2022, see
 # the COPYRIGHT file for more information.
 
 # Ed Hartnett, Russ Rew, Dennis Heimbigner, Ward Fisher


### PR DESCRIPTION
Fixes #343 

Add parallel I/O build and test for netcdf-fortran with autotools and add hdf5-1.12.1 testing.