### PR TITLE
bug fix: when all parallel features are disabled in netcdf-c

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -12,18 +12,19 @@ SET(netcdff_SOURCES
   nf_varmio.F90 nf_varsio.F90
 )
 
-# Check if netcdf-c has parallel I/O functions
-check_symbol_exists(nc_create_par "netcdf.h" HAVE_PARALLEL)
-message (STATUS "found netcdf-c parallel support: ${HAVE_PARALLEL}")
-IF (${USE_NETCDF4})
-IF(HAVE_PARALLEL)
-  SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc.f90)
-  message (STATUS "including netcdf-f parallel support")
-ELSE ()
-  SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc_noparallel.f90)
-  message (STATUS "no netcdf-f parallel support")
-ENDIF(HAVE_PARALLEL)
-ENDIF(${USE_NETCDF4} AND HAVE_PARALLEL)
+# Check if netcdf-c has parallel I/O feature enabled
+IF (NETCDF_C_INCLUDE_DIR)
+   file(READ "${NETCDF_C_INCLUDE_DIR}/netcdf_meta.h" header)
+   string(REGEX MATCH "#define NC_HAS_PARALLEL *[01]" macrodef "${header}")
+   string(REGEX MATCH "[01]" HAVE_PARALLEL "${macrodef}")
+   IF (HAVE_PARALLEL)
+      SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc.f90)
+      MESSAGE(STATUS "Whether NetCDF-C built with paralle I/O enabled: yes")
+   ELSE()
+      SET(netcdff_SOURCES ${netcdff_SOURCES} nf_nc_noparallel.f90)
+      MESSAGE(STATUS "Whether NetCDF-C built with paralle I/O enabled: no")
+   ENDIF(HAVE_PARALLEL)
+ENDIF(NETCDF_C_INCLUDE_DIR)
 
 IF (USE_NETCDF4)
   SET(netcdff_SOURCES ${netcdff_SOURCES}

--- a/fortran/Makefile.am
+++ b/fortran/Makefile.am
@@ -42,7 +42,13 @@ libnetcdf_nf_interfaces.la libnetcdfm.la libnetcdf_f03.la
 libnetcdff_la_SOURCES = nf_attio.F90 nf_control.F90 nf_dim.f90		\
 nf_misc.f90 nf_genatt.f90 nf_geninq.f90 nf_genvar.f90 nf_vario.F90	\
 nf_var1io.F90 nf_varaio.F90 nf_varmio.F90 nf_varsio.F90			\
-nf_logging.F90 nf_nc.f90
+nf_logging.F90
+
+if BUILD_PARALLEL
+libnetcdff_la_SOURCES += nf_nc.f90
+else
+libnetcdff_la_SOURCES += nf_nc_noparallel.f90
+endif
 
 # The respective objects depend on the netcdf_nc_interfaces module.
 nf_attio.lo nf_control.lo nf_dim.lo nf_genatt.lo nf_geninq.lo nf_genvar.lo    \


### PR DESCRIPTION
Look like this same fix has already appeared in fortran/CMakeLists.txt
by @brucenairn in 340b07a7b38529c9dbe0164f4339557be23c937e