### PR TITLE
protect quantize code with preprocessor directives

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,18 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 AC_MSG_RESULT([$nc_has_szip_write])
 AM_CONDITIONAL(TEST_SZIP_WRITE, [test "x$nc_has_szip_write" = xyes])
 
+AC_MSG_CHECKING([if netCDF was built with support for quantize])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#include <netcdf_meta.h>
+#if !defined(NC_HAS_QUANTIZE) || NC_HAS_QUANTIZE == 0
+      choke me
+#endif]])], [nc_has_quantize=yes], [nc_has_quantize=no])
+if test "x$nc_has_quantize" = xyes; then
+   AC_DEFINE([NF_HAS_QUANTIZE], [1], [Support for quantize feature.])
+fi
+AC_MSG_RESULT([$nc_has_quantize])
+AM_CONDITIONAL(TEST_QUANTIZE, [test "x$nc_has_quantize" = xyes])
+
 # Find valgrind, if available, and add targets for it (ex:
 # check-valgrind).
 AX_VALGRIND_DFLT([sgcheck], [off])
@@ -605,6 +617,7 @@ AC_SUBST(HAS_DAP,[$nc_has_dap])
 AC_SUBST(HAS_NC2,[$nc_build_v2])
 AC_SUBST(HAS_NC4,[$nc_build_v4])
 AC_SUBST(HAS_SZIP_WRITE,[$nc_has_szip_write])
+AC_SUBST(HAS_QUANTIZE,[$nc_has_quantize])
 AC_SUBST(HAS_LOGGING,[$nc_has_logging])
 AC_SUBST(HAS_CDF5,[$nc_has_cdf5])
 AC_SUBST(HAS_PNETCDF,[$nc_has_pnetcdf])

--- a/fortran/netcdf4.inc
+++ b/fortran/netcdf4.inc
@@ -151,6 +151,8 @@
       parameter (nf_edimscale = -124)
       integer nf_enogrp       ! No group found.
       parameter (nf_enogrp = -125)
+      integer nf_enotbuilt       ! NetCDF feature not built.
+      parameter (nf_enotbuilt = -128)
 
 
 !     New functions.

--- a/fortran/netcdf4_func.F90
+++ b/fortran/netcdf4_func.F90
@@ -538,7 +538,11 @@
     integer, intent(in) :: nsd
     integer :: nf90_def_var_quantize
 
+#ifdef NF_HAS_QUANTIZE
     nf90_def_var_quantize = nf_def_var_quantize(ncid, varid, quantize_mode, nsd)
+#else
+    nf90_def_var_quantize = nf90_enotbuilt
+#endif
   end function nf90_def_var_quantize
   ! -----------
   function nf90_def_var_fletcher32(ncid, varid, fletcher32)
@@ -588,7 +592,11 @@
     integer, intent(out) :: nsd
     integer :: nf90_inq_var_quantize
 
+#ifdef NF_HAS_QUANTIZE
     nf90_inq_var_quantize = nf_inq_var_quantize(ncid, varid, quantize_mode, nsd)
+#else
+    nf90_inq_var_quantize = nf90_enotbuilt
+#endif
   end function nf90_inq_var_quantize
   ! -----------
   function nf90_inq_var_fletcher32(ncid, varid, fletcher32)

--- a/fortran/netcdf4_variables.F90
+++ b/fortran/netcdf4_variables.F90
@@ -126,13 +126,16 @@
 
     ! Set quantize if the user wants to.
     if (present(quantize_mode)) then
+#ifdef NF_HAS_QUANTIZE
        if (.not. present(nsd)) then
           nf90_def_var_oneDim = nf90_einval
           return
        endif
        nf90_def_var_oneDim = nf_def_var_quantize(ncid, varid, quantize_mode, nsd)
        if (nf90_def_var_oneDim .ne. nf90_noerr) return
-       
+#else
+       nf90_def_var_oneDim = nf90_enotbuilt
+#endif
     endif
        
 
@@ -255,12 +258,16 @@
 
     ! Set quantize if the user wants to.
     if (present(quantize_mode)) then
+#ifdef NF_HAS_QUANTIZE
        if (.not. present(nsd)) then
           nf90_def_var_ManyDims = nf90_einval
           return
        endif
        nf90_def_var_ManyDims = nf_def_var_quantize(ncid, varid, quantize_mode, nsd)
        if (nf90_def_var_ManyDims .ne. nf90_noerr) return
+#else
+       nf90_def_var_ManyDims = nf90_enotbuilt
+#endif
     endif
        
   end function nf90_def_var_ManyDims
@@ -376,8 +383,14 @@
 
     ! And the quantization...
     if (present(quantize_mode)) then
+#ifdef NF_HAS_QUANTIZE       
        nf90_inquire_variable = nf_inq_var_quantize(ncid, varid, quantize_mode, nsd)
        if (nf90_inquire_variable .ne. nf90_noerr) return
+#else
+       quantize_mode = 0
+       nsd = 0
+       nf90_inquire_variable = nf90_noerr
+#endif
     endif
     
   end function nf90_inquire_variable

--- a/fortran/nf_nc4.F90
+++ b/fortran/nf_nc4.F90
@@ -1584,7 +1584,11 @@
  cquantize_mode = quantize_mode
  cnsd = nsd
 
+#ifdef NF_HAS_QUANTIZE 
  cstatus = nc_def_var_quantize(cncid, cvarid, cquantize_mode, cnsd)
+#else
+ cstatus = nc_enotbuilt
+#endif
  status = cstatus
 
  End Function nf_def_var_quantize
@@ -1607,7 +1611,11 @@
  cncid  = ncid
  cvarid = varid-1
 
+#ifdef NF_HAS_QUANTIZE
  cstatus = nc_inq_var_quantize(cncid, cvarid, cquantize_mode, cnsd)
+#else
+ cstatus = nc_enotbuilt
+#endif
 
  If (cstatus == NC_NOERR) Then
     quantize_mode     = cquantize_mode

--- a/nf03_test4/Makefile.am
+++ b/nf03_test4/Makefile.am
@@ -14,8 +14,13 @@ LDADD = ${top_builddir}/fortran/libnetcdff.la
 
 # tst_f90_nc4
 NC4_F90_TESTS = f90tst_vars f90tst_vars_vlen f90tst_grps f90tst_fill	\
-f90tst_fill2 f90tst_vars2 f90tst_vars3 f90tst_vars4 f90tst_vars5	\
-f90tst_path f90tst_rengrps f90tst_nc4 f90tst_types f90tst_types2
+f90tst_fill2 f90tst_vars2 f90tst_vars3 f90tst_vars4 f90tst_path		\
+f90tst_rengrps f90tst_nc4 f90tst_types f90tst_types2
+
+if TEST_QUANTIZE
+NC4_F90_TESTS += f90tst_vars5
+endif
+
 check_PROGRAMS = $(NC4_F90_TESTS)
 TESTS = $(NC4_F90_TESTS)
 

--- a/nf03_test4/f90tst_vars5.F90
+++ b/nf03_test4/f90tst_vars5.F90
@@ -4,7 +4,7 @@
 
 !     This program tests netCDF-4 variable functions from fortran.
 
-!     $Id: f90tst_vars2.f90,v 1.7 2010/01/25 21:01:07 ed Exp $
+!     Ed Hartnett 2010/01/25
 
 program f90tst_vars5
   use typeSizes
@@ -76,7 +76,7 @@ program f90tst_vars5
   call check(nf90_def_dim(ncid, "x", DIM_LEN_5, x_dimid))
   dimids =  (/ x_dimid /)
 
-  ! Define some variables. 
+  ! Define some variables.
   call check(nf90_def_var(ncid, VAR1_NAME, NF90_FLOAT, dimids, varid1&
        &, deflate_level = DEFLATE_LEVEL, quantize_mode =&
        & nf90_quantize_bitgroom, nsd = 3))
@@ -134,7 +134,7 @@ program f90tst_vars5
        natts_in .ne. 1 .or. dimids_in(1) .ne. dimids(1)) stop 6
   if (deflate_level_in .ne. 0 .or. .not. contiguous_in .or. fletcher32_in .or. shuffle_in) stop 7
   if (quantize_mode_in .ne. nf90_quantize_bitgroom .or. nsd_in .ne. 3) stop 3
-
+  
   ! Check the data.
   call check(nf90_get_var(ncid, varid1_in, real_data_in))
   call check(nf90_get_var(ncid, varid2_in, double_data_in))

--- a/nf_test4/Makefile.am
+++ b/nf_test4/Makefile.am
@@ -13,8 +13,13 @@ LDADD = ${top_builddir}/fortran/libnetcdff.la
 
 # These programs test the F77 netCDF-4 API using include netcdf.inc.
 NF77_TESTS = ftst_groups ftst_vars ftst_vars2 ftst_vars3 ftst_vars4	\
-ftst_vars5 ftst_vars6 ftst_vars7 ftst_types ftst_types2 ftst_types3	\
-ftst_path ftst_rengrps f03tst_open_mem ftst_var_compact
+ftst_vars5 ftst_vars6 ftst_types ftst_types2 ftst_types3 ftst_path	\
+ftst_rengrps f03tst_open_mem ftst_var_compact
+
+# Only build and run this test if quantize feature is supported.
+if TEST_QUANTIZE
+NF77_TESTS += ftst_vars7
+endif
 
 # Compile and run the F77 API tests.
 check_PROGRAMS = $(NF77_TESTS)
@@ -74,12 +79,18 @@ if USE_SED
 # These test fortran codes will be created using sed.
 F03_TEST_CODES = f03tst_groups.F f03tst_vars.F f03tst_vars2.F	\
 f03tst_vars3.F f03tst_vars4.F f03tst_vars5.F f03tst_vars6.F	\
-f03tst_vars7.F f03tst_types.F f03tst_types2.F f03tst_types3.F
+f03tst_types.F f03tst_types2.F f03tst_types3.F
 
 # The fortran codes will compile into these tests.
 F03_TESTS = f03tst_groups f03tst_vars f03tst_vars2 f03tst_vars3		\
-f03tst_vars4 f03tst_vars5 f03tst_vars6 f03tst_vars7 f03tst_types	\
-f03tst_types2 f03tst_types3
+f03tst_vars4 f03tst_vars5 f03tst_vars6 f03tst_types f03tst_types2	\
+f03tst_types3
+
+# If quantize is available, run this test.
+if TEST_QUANTIZE
+F03_TEST_CODES += f03tst_vars7.F
+F03_TESTS +=  f03tst_vars7
+endif
 
 # This is a netCDF-4 V2 F77 test program.
 if BUILD_V2


### PR DESCRIPTION
Fixes #355
Fixes #214

In this PR I protect the quantize code and tests so they are not included when netcdf-c does not support quantize.

After this PR is merged, netcdf-fortran will once again be able to build with netcdf-c-4.7.4, 4.8.0, and 4.8.1, as well as 4.9.0.