### PR TITLE
Compile i8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ CTestConfig.cmake
 *.*~
 html
 .idea
+CMakeLists_org.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@
 #Minimum required CMake Version
 cmake_minimum_required(VERSION 3.12.0)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 #Project Name for netCDF-Fortran
 PROJECT (NC4F
 LANGUAGES C Fortran
@@ -338,7 +340,7 @@ ENDMACRO()
 # CRT libs, MT tells VS to use the static CRT libs.
 #
 # Taken From:
-# 	http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
+#   http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
 #
 MACRO(specify_static_crt_flag)
 
@@ -641,7 +643,7 @@ CHECK_LIBRARY_EXISTS(${NETCDF_C_LIBRARY} oc_open "" BUILD_DAP)
 ###
 # Check to see if szip write capability is present in netcdf-c.
 ###
-SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
+SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_C_INCLUDE_DIR})
 CHECK_C_SOURCE_COMPILES("
 #include <netcdf_meta.h>
 #if !NC_HAS_SZIP_WRITE
@@ -652,7 +654,7 @@ int main() {return 0;}" HAVE_SZIP_WRITE)
 ###
 # Check to see if quantize capability is present in netcdf-c.
 ###
-SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
+SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_C_INCLUDE_DIR})
 CHECK_C_SOURCE_COMPILES("
 #include <netcdf_meta.h>
 #if !NC_HAS_QUANTIZE
@@ -678,8 +680,8 @@ endif()
 
 OPTION(DISABLE_ZSTANDARD_PLUGIN "Disable ZStandard plugin detection and functionality, even if libnetcdf was compiled with plugin support" OFF)
 
-IF(NOT DISABLE_ZSTANDARD_PLUGIN) 
-  SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
+IF(NOT DISABLE_ZSTANDARD_PLUGIN)
+  SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_C_INCLUDE_DIR})
   CHECK_C_SOURCE_COMPILES("
   #include <netcdf_meta.h>
   #if !NC_HAS_ZSTD

--- a/nf_test/CMakeLists.txt
+++ b/nf_test/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Process these files with m4.
 SET(m4_SOURCES test_get test_put)
 foreach (f ${m4_SOURCES})
-		   GEN_m4(${f})
+       GEN_m4(${f})
 endforeach(f)
 
 # Separate C and Fortran Sources
@@ -37,8 +37,10 @@ IF(NOT NETCDF_C_LIBRARY)
 ENDIF()
 
 # Need a copy of ref_fills.nc for ftest
-execute_process(COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/ref_fills.nc
-  ${CMAKE_CURRENT_BINARY_DIR}/fills.nc)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ref_fills.nc
+          DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/ref_fills.nc
+            ${CMAKE_CURRENT_BINARY_DIR}/fills.nc)
 
 INCLUDE_DIRECTORIES(BEFORE
   ${CMAKE_CURRENT_BINARY_DIR}
@@ -74,14 +76,13 @@ ENDFOREACH()
 # Copy test scripts in to current directory.
 FILE(GLOB COPY_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.sh)
 FILE(COPY ${COPY_FILES}
-	  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/
-	  FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE)
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/
+    FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE)
 
 # Add script-based tests.
 FOREACH(t ${SCRIPT_TESTS})
   add_sh_test(nf_test ${t})
 ENDFOREACH()
-
 
 # test_get.F and test_put.f need to be distributed, so that the user
 # need not have m4. fills.nc is used by test program ftest.


### PR DESCRIPTION
### Changes required for a clean Windows build

Build Environment:
Windows 11 Pro
Visual Studio 2022 with Intel Fortran 2023.1
CMake 3.26.4

The C compiler identification is MSVC 19.36.32535.0
The Fortran compiler identification is Intel 2021.9.0.20230302

### Build a Windows shared lib

File ./CMakeLists.txt
Symbols are not automatically exported.  Added cmake command to export all symbols.  This creates "exports.def" which could be edited to remove unnecessary symbols. I can provide this file on request.
set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

Without this, netcdff.lib is not generated.

### Config tests failures

File ./CMakeLists.txt
In three places, config tests fail because the include folder is wrong. The tests fail because they cannot find "netcdf_meta.h"
-SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
SET(CMAKE_REQUIRED_INCLUDES ${NETCDF_C_INCLUDE_DIR})

### RUN_TESTS failures

ftest:
BUILD_DIR/nf_test/fills.nc is missing.

The "cp" command is unix only.  Use cmake commands COPY/RENAME.

File ./nf_test/CMakeLists.txt
-execute_process(COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/ref_fills.nc
file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ref_fills.nc
           DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/ref_fills.nc
            ${CMAKE_CURRENT_BINARY_DIR}/fills.nc)

---------------------------------

f90tst_vars4:
netcdf_expanded.F90 segfaults at line 1950:
     values(:, :) = reshape(defaultIntArray(:), shape(values))
nf90_get_var_2D_FourByteInt

defaultIntArray is a large array on the stack that causes a stack overflow.
I used a compiler flag to switch stack arrays to the heap, but the best
solution would be to ALLOCATE these arrays and move them off the stack.

Manually added /heap-arrays:1 to the netcdff project to get a successful test.

**_I did not commit any changes to address this issue because the temporary fix is compiler specific._**

---------------------------------

### Here are the logs of the failures to support the changes:

File CMakeConfigureLog.yaml

    kind: "try_compile-v1"
    backtrace:
      - "C:/Program Files/CMake/share/cmake-3.26/Modules/Internal/CheckSourceCompiles.cmake:101 (try_compile)"
      - "C:/Program Files/CMake/share/cmake-3.26/Modules/CheckCSourceCompiles.cmake:76 (cmake_check_source_compiles)"
      - "CMakeLists.txt:648 (CHECK_C_SOURCE_COMPILES)"
    checks:
      - "Performing Test HAVE_SZIP_WRITE"
    directories:
      source: "C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-h7ccse"
      binary: "C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-h7ccse"
    cmakeVariables:
      CMAKE_C_FLAGS: "/DWIN32 /D_WINDOWS /W3 -O2"
      CMAKE_C_FLAGS_DEBUG: "/MDd /Zi /Ob0 /Od /RTC1"
      CMAKE_EXE_LINKER_FLAGS: "/machine:x64"
      CMAKE_MODULE_PATH: "C:/Lib/tmp/netcdf-fortran/cmake/modules/"
      CMAKE_POSITION_INDEPENDENT_CODE: "ON"
    buildResult:
      variable: "HAVE_SZIP_WRITE"
      cached: true
      stdout: |
        Change Dir: C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-h7ccse

        Run Build Command(s):C:/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/amd64/MSBuild.exe cmTC_01def.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:VisualStudioVersion=17.0 /v:n && MSBuild version 17.6.3+07e294721 for .NET Framework
        Build started 7/10/2023 4:33:27 PM.

        Project "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\cmTC_01def.vcxproj" on node 1 (default targets).
        PrepareForBuild:
          Creating directory "cmTC_01def.dir\\Debug\\".
          Creating directory "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\Debug\\".
          Creating directory "cmTC_01def.dir\\Debug\\cmTC_01def.tlog\\".
        InitializeBuildStatus:
          Creating "cmTC_01def.dir\\Debug\\cmTC_01def.tlog\\unsuccessfulbuild" because "AlwaysCreate" was specified.
        ClCompile:
          C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.36.32532\\bin\\HostX64\\x64\\CL.exe /c /Zi /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D HAVE_SZIP_WRITE /D "CMAKE_INTDIR=\\"Debug\\"" /Gm- /RTC1 /MDd /GS /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_01def.dir\\Debug\\\\" /Fd"cmTC_01def.dir\\Debug\\vc143.pdb" /external:W3 /Gd /TC /errorReport:queue "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\src.c"
          Microsoft (R) C/C++ Optimizing Compiler Version 19.36.32535 for x64
          src.c
          Copyright (C) Microsoft Corporation.  All rights reserved.
          cl /c /Zi /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D HAVE_SZIP_WRITE /D "CMAKE_INTDIR=\\"Debug\\"" /Gm- /RTC1 /MDd /GS /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_01def.dir\\Debug\\\\" /Fd"cmTC_01def.dir\\Debug\\vc143.pdb" /external:W3 /Gd /TC /errorReport:queue "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\src.c"
        C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\src.c(2,10): fatal  error C1083: Cannot open include file: 'netcdf_meta.h': No such file or directory [C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\cmTC_01def.vcxproj]
        Done Building Project "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\cmTC_01def.vcxproj" (default targets) -- FAILED.

        Build FAILED.

        "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\cmTC_01def.vcxproj" (default target) (1) ->
        (ClCompile target) ->
          C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\src.c(2,10): fatal  error C1083: Cannot open include file: 'netcdf_meta.h': No such file or directory [C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-h7ccse\\cmTC_01def.vcxproj]

            0 Warning(s)
            1 Error(s)

        Time Elapsed 00:00:00.35

      exitCode: 1
---------------------------------
    kind: "try_compile-v1"
    backtrace:
      - "C:/Program Files/CMake/share/cmake-3.26/Modules/Internal/CheckSourceCompiles.cmake:101 (try_compile)"
      - "C:/Program Files/CMake/share/cmake-3.26/Modules/CheckCSourceCompiles.cmake:76 (cmake_check_source_compiles)"
      - "CMakeLists.txt:662 (CHECK_C_SOURCE_COMPILES)"
    checks:
      - "Performing Test HAVE_QUANTIZE"
    directories:
      source: "C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-j26q01"
      binary: "C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-j26q01"
    cmakeVariables:
      CMAKE_C_FLAGS: "/DWIN32 /D_WINDOWS /W3 -O2"
      CMAKE_C_FLAGS_DEBUG: "/MDd /Zi /Ob0 /Od /RTC1"
      CMAKE_EXE_LINKER_FLAGS: "/machine:x64"
      CMAKE_MODULE_PATH: "C:/Lib/tmp/netcdf-fortran/cmake/modules/"
      CMAKE_POSITION_INDEPENDENT_CODE: "ON"
    buildResult:
      variable: "HAVE_QUANTIZE"
      cached: true
      stdout: |
        Change Dir: C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-j26q01

        Run Build Command(s):C:/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/amd64/MSBuild.exe cmTC_219b6.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:VisualStudioVersion=17.0 /v:n && MSBuild version 17.6.3+07e294721 for .NET Framework
        Build started 7/10/2023 4:33:28 PM.

        Project "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\cmTC_219b6.vcxproj" on node 1 (default targets).
        PrepareForBuild:
          Creating directory "cmTC_219b6.dir\\Debug\\".
          Creating directory "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\Debug\\".
          Creating directory "cmTC_219b6.dir\\Debug\\cmTC_219b6.tlog\\".
        InitializeBuildStatus:
          Creating "cmTC_219b6.dir\\Debug\\cmTC_219b6.tlog\\unsuccessfulbuild" because "AlwaysCreate" was specified.
        ClCompile:
          C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.36.32532\\bin\\HostX64\\x64\\CL.exe /c /Zi /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D HAVE_QUANTIZE /D "CMAKE_INTDIR=\\"Debug\\"" /Gm- /RTC1 /MDd /GS /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_219b6.dir\\Debug\\\\" /Fd"cmTC_219b6.dir\\Debug\\vc143.pdb" /external:W3 /Gd /TC /errorReport:queue "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\src.c"
          Microsoft (R) C/C++ Optimizing Compiler Version 19.36.32535 for x64
          src.c
          Copyright (C) Microsoft Corporation.  All rights reserved.
          cl /c /Zi /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D HAVE_QUANTIZE /D "CMAKE_INTDIR=\\"Debug\\"" /Gm- /RTC1 /MDd /GS /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_219b6.dir\\Debug\\\\" /Fd"cmTC_219b6.dir\\Debug\\vc143.pdb" /external:W3 /Gd /TC /errorReport:queue "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\src.c"
        C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\src.c(2,10): fatal  error C1083: Cannot open include file: 'netcdf_meta.h': No such file or directory [C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\cmTC_219b6.vcxproj]
        Done Building Project "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\cmTC_219b6.vcxproj" (default targets) -- FAILED.

        Build FAILED.

        "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\cmTC_219b6.vcxproj" (default target) (1) ->
        (ClCompile target) ->
          C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\src.c(2,10): fatal  error C1083: Cannot open include file: 'netcdf_meta.h': No such file or directory [C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-j26q01\\cmTC_219b6.vcxproj]

            0 Warning(s)
            1 Error(s)

        Time Elapsed 00:00:00.35

      exitCode: 1
---------------------------------
    kind: "try_compile-v1"
    backtrace:
      - "C:/Program Files/CMake/share/cmake-3.26/Modules/Internal/CheckSourceCompiles.cmake:101 (try_compile)"
      - "C:/Program Files/CMake/share/cmake-3.26/Modules/CheckCSourceCompiles.cmake:76 (cmake_check_source_compiles)"
      - "CMakeLists.txt:692 (CHECK_C_SOURCE_COMPILES)"
    checks:
      - "Performing Test NC_HAVE_ZSTD"
    directories:
      source: "C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-d9fg93"
      binary: "C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-d9fg93"
    cmakeVariables:
      CMAKE_C_FLAGS: "/DWIN32 /D_WINDOWS /W3 -O2"
      CMAKE_C_FLAGS_DEBUG: "/MDd /Zi /Ob0 /Od /RTC1"
      CMAKE_EXE_LINKER_FLAGS: "/machine:x64"
      CMAKE_MODULE_PATH: "C:/Lib/tmp/netcdf-fortran/cmake/modules/"
      CMAKE_POSITION_INDEPENDENT_CODE: "ON"
    buildResult:
      variable: "NC_HAVE_ZSTD"
      cached: true
      stdout: |
        Change Dir: C:/Lib/tmp/build64/CMakeFiles/CMakeScratch/TryCompile-d9fg93

        Run Build Command(s):C:/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/amd64/MSBuild.exe cmTC_4e03b.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:VisualStudioVersion=17.0 /v:n && MSBuild version 17.6.3+07e294721 for .NET Framework
        Build started 7/10/2023 4:33:29 PM.

        Project "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\cmTC_4e03b.vcxproj" on node 1 (default targets).
        PrepareForBuild:
          Creating directory "cmTC_4e03b.dir\\Debug\\".
          Creating directory "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\Debug\\".
          Creating directory "cmTC_4e03b.dir\\Debug\\cmTC_4e03b.tlog\\".
        InitializeBuildStatus:
          Creating "cmTC_4e03b.dir\\Debug\\cmTC_4e03b.tlog\\unsuccessfulbuild" because "AlwaysCreate" was specified.
        ClCompile:
          C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.36.32532\\bin\\HostX64\\x64\\CL.exe /c /Zi /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D NC_HAVE_ZSTD /D "CMAKE_INTDIR=\\"Debug\\"" /Gm- /RTC1 /MDd /GS /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_4e03b.dir\\Debug\\\\" /Fd"cmTC_4e03b.dir\\Debug\\vc143.pdb" /external:W3 /Gd /TC /errorReport:queue "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\src.c"
          Microsoft (R) C/C++ Optimizing Compiler Version 19.36.32535 for x64
          src.c
          Copyright (C) Microsoft Corporation.  All rights reserved.
          cl /c /Zi /W3 /WX- /diagnostics:column /Od /Ob0 /D _MBCS /D WIN32 /D _WINDOWS /D NC_HAVE_ZSTD /D "CMAKE_INTDIR=\\"Debug\\"" /Gm- /RTC1 /MDd /GS /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_4e03b.dir\\Debug\\\\" /Fd"cmTC_4e03b.dir\\Debug\\vc143.pdb" /external:W3 /Gd /TC /errorReport:queue "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\src.c"
        C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\src.c(2,12): fatal  error C1083: Cannot open include file: 'netcdf_meta.h': No such file or directory [C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\cmTC_4e03b.vcxproj]
        Done Building Project "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\cmTC_4e03b.vcxproj" (default targets) -- FAILED.

        Build FAILED.

        "C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\cmTC_4e03b.vcxproj" (default target) (1) ->
        (ClCompile target) ->
          C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\src.c(2,12): fatal  error C1083: Cannot open include file: 'netcdf_meta.h': No such file or directory [C:\\Lib\\tmp\\build64\\CMakeFiles\\CMakeScratch\\TryCompile-d9fg93\\cmTC_4e03b.vcxproj]

            0 Warning(s)
            1 Error(s)

        Time Elapsed 00:00:00.35

      exitCode: 1
---------------------------------

### Build RUN_TESTS failures

4/50 Testing: ftest
4/50 Test: ftest
Command: "C:/Lib/tmp/build64/nf_test/Debug/ftest.exe"
Directory: C:/Lib/tmp/build64/nf_test
"ftest" start time: Jul 11 16:58 Central Daylight Time
Output:
----------------------------------------------------------

 *** Testing netCDF-2 Fortran 77 API.
 *** testing nccre ...
 *** testing ncddef ...
 *** testing ncvdef ...
 *** testing ncapt, ncaptc ...
 *** testing ncclos ...
 *** testing ncvpt1 ...
 *** testing ncvgt1 ...
 *** testing ncvpt ...
 *** testing ncopn, ncinq, ncdinq, ncvinq, ncanam, ncainq ...
 *** testing ncvgt, ncvgtc ...
 *** testing ncagt, ncagtc ...
 *** testing ncredf, ncdren, ncvren, ncaren, ncendf ...
 *** testing ncacpy ...
 *** testing ncadel ...
 *** testing fill values ...
ncopen: filename "fills.nc": No such file or directory
NCOPN: : Unknown Error
ncvarid: ncid -1: NetCDF: Not a valid ID
ncvarid: ncid -1: NetCDF: Not a valid ID
ncvarid: ncid -1: NetCDF: Not a valid ID
ncvarid: ncid -1: NetCDF: Not a valid ID
ncvarid: ncid -1: NetCDF: Not a valid ID
NCVGT1: : NetCDF: Not a valid ID
NCVGT1: : NetCDF: Not a valid ID
NCVGT1: : NetCDF: Not a valid ID
NCVGT1: : NetCDF: Not a valid ID
NCVGT1: : NetCDF: Not a valid ID
 error in byte fill value
 error in double fill value
 error in float fill value
 error in long fill value
 error in short fill value
 Total number of failures:           11
2
<end of output>
Test time =   0.06 sec
----------------------------------------------------------
Test Failed.
"ftest" end time: Jul 11 16:58 Central Daylight Time
"ftest" time elapsed: 00:00:00
----------------------------------------------------------

30/50 Testing: f90tst_vars4
30/50 Test: f90tst_vars4
Command: "C:/Lib/tmp/build64/nf03_test4/Debug/f90tst_vars4.exe"
Directory: C:/Lib/tmp/build64/nf03_test4
"f90tst_vars4" start time: Jul 11 16:58 Central Daylight Time
Output:
----------------------------------------------------------

 *** Testing definition of netCDF-4 vars from Fortran 90.
forrtl: severe (170): Program Exception - stack overflow
Image              PC                Routine            Line        Source
netcdff.dll        00007FFBC52ADEF7  Unknown               Unknown  Unknown
netcdff.dll        00007FFBC51CDD48  Unknown               Unknown  Unknown
f90tst_vars4.exe   00007FF7AA8720D9  Unknown               Unknown  Unknown
f90tst_vars4.exe   00007FF7AA87287B  Unknown               Unknown  Unknown
f90tst_vars4.exe   00007FF7AA874039  Unknown               Unknown  Unknown
f90tst_vars4.exe   00007FF7AA873EDE  Unknown               Unknown  Unknown
f90tst_vars4.exe   00007FF7AA873D9E  Unknown               Unknown  Unknown
f90tst_vars4.exe   00007FF7AA8740CE  Unknown               Unknown  Unknown
KERNEL32.DLL       00007FFC69E826AD  Unknown               Unknown  Unknown
ntdll.dll          00007FFC6A44AA68  Unknown               Unknown  Unknown
<end of output>
Test time =   0.14 sec
----------------------------------------------------------
Test Failed.
"f90tst_vars4" end time: Jul 11 16:58 Central Daylight Time
"f90tst_vars4" time elapsed: 00:00:00
----------------------------------------------------------


