### PR TITLE
Use install directory that matches package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1187,7 +1187,7 @@ FILE(COPY "${CMAKE_BINARY_DIR}/tmp/nf-config"
 
 include(CMakePackageConfigHelpers)
 
-set(ConfigPackageLocation "${CMAKE_INSTALL_LIBDIR}/cmake/netCDF")
+set(ConfigPackageLocation "${CMAKE_INSTALL_LIBDIR}/cmake/netCDF-Fortran")
 
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/netCDF-FortranConfigVersion.cmake"


### PR DESCRIPTION
To follow cmake `find_pacakge()` search procedure rules, the install directory name should match the package name:
https://cmake.org/cmake/help/v3.20/command/find_package.html#search-procedure

With this change, now `find_package` should work even when specifying only `netCDF-Fortran_ROOT` (thus running in [Config Mode](https://cmake.org/cmake/help/v3.20/command/find_package.html#full-signature-and-config-mode)), which has the highest search precedence since CMake 3.12

Future improvements might include a variable to replace all instances of the string `netCDF-Fortran` so that variables or functions that ought to use the package name can source from one definition.