### PR TITLE
Clarify 'netCDF-C 4.7.4 or greater required' message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,7 +669,7 @@ endif()
 
 CHECK_LIBRARY_EXISTS(${NETCDF_C_LIBRARY} nc_def_var_szip "" HAVE_DEF_VAR_SZIP)
 if (NOT HAVE_DEF_VAR_SZIP)
-  message(FATAL_ERROR "netcdf-c version 4.7.4 or greater is required")
+  message(FATAL_ERROR "netcdf-c version 4.7.4 or greater is required, built with underlying szip support.")
 endif()
 
 ###

--- a/configure.ac
+++ b/configure.ac
@@ -553,7 +553,7 @@ AC_CHECK_FUNCS([nc_def_opaque nccreate nc_set_log_level oc_open nc_def_var_szip]
 
 # Starting with version 4.7.4, netcdf-c has function nc_def_var_szip().
 if test "x$ac_cv_func_nc_def_var_szip" != xyes; then
-   AC_MSG_ERROR([netcdf-c version 4.7.4 or greater is required])
+   AC_MSG_ERROR([netcdf-c version 4.7.4 or greater is required, built with underlying szip support.])
 fi
 
 nc_build_v2=no


### PR DESCRIPTION
* Fixes #278 

Draft pull request, we need more than a simple message update.  I'll review to see if there's a way we can fencepost around the `szip` functionality we're checking for, and if we can introduce an alternative check that will allow linking against a libnetcdf 4.7.4+ linking against `libhdf5` built without szip support. 