### PR TITLE
Clarify message when failing with 'requires v4.7.4' error. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,7 +669,12 @@ endif()
 
 CHECK_LIBRARY_EXISTS(${NETCDF_C_LIBRARY} nc_def_var_szip "" HAVE_DEF_VAR_SZIP)
 if (NOT HAVE_DEF_VAR_SZIP)
-  message(FATAL_ERROR "netcdf-c version 4.7.4 or greater is required, built with underlying szip support.")
+  message(FATAL_ERROR "netcdf-c version 4.7.4 or greater is required."
+                      "If netCDF-C 4.7.4 is present but is built statically, you *must* specify all dependencies"
+                      "by setting the LDFLAGS environmental variable.\n"
+                      "Example:\n"
+                      "    $ export LDFLAGS=$(nc-config --libs)"
+                      )
 endif()
 
 ###


### PR DESCRIPTION
* Fixes #278 

There may be an elegant solution, but for now we will just provide instructions alongside the error.  When cmake invokes `CHECK_LIBRARY_EXISTS()` against a static library (such as `libnetcdf.a`), the dependencies must be specified manually, since there is no way to infer these dependencies with static libraries; this can be handled programmatically in the `CMakeLists.txt` file, where we check for `nc-config` and, if present, use the output of `nc-config --libs`, but for now we will just present this information when encountering this error.  

The fix is to set `LDFLAGS` to the output from `nc-config --libs`. 