### PR TITLE
Fix size() for large variables >= 2^31 values

### DIFF
--- a/fortran/netcdf4_eightbyte.F90
+++ b/fortran/netcdf4_eightbyte.F90
@@ -396,7 +396,7 @@ function nf90_get_var_1D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_1D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_1D_EightByteInt = &
@@ -411,7 +411,7 @@ function nf90_get_var_1D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_1D_EightByteInt = &
@@ -458,7 +458,7 @@ function nf90_get_var_2D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_2D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_2D_EightByteInt = &
@@ -473,7 +473,7 @@ function nf90_get_var_2D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:, :) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_2D_EightByteInt = &
@@ -520,7 +520,7 @@ function nf90_get_var_3D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_3D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_3D_EightByteInt = &
@@ -535,7 +535,7 @@ function nf90_get_var_3D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:, :, :) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_3D_EightByteInt = &
@@ -582,7 +582,7 @@ function nf90_get_var_4D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_4D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_4D_EightByteInt = &
@@ -597,7 +597,7 @@ function nf90_get_var_4D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:, :, :, :) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_4D_EightByteInt = &
@@ -644,7 +644,7 @@ function nf90_get_var_5D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_5D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_5D_EightByteInt = &
@@ -659,7 +659,7 @@ function nf90_get_var_5D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:, :, :, :, :) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_5D_EightByteInt = &
@@ -706,7 +706,7 @@ function nf90_get_var_6D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_6D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_6D_EightByteInt = &
@@ -721,7 +721,7 @@ function nf90_get_var_6D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:, :, :, :, :, :) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_6D_EightByteInt = &
@@ -768,7 +768,7 @@ function nf90_get_var_7D_EightByteInt(ncid, varid, values, start, count, stride,
   if (nf90_get_var_7D_EightByteInt .eq. nf90_noerr) then
      if (format_num .eq. nf90_format_netcdf4 .OR. &
          format_num .eq. nf90_format_cdf5) then
-        allocate(defaultInt8Array(size(values)))
+        allocate(defaultInt8Array(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_7D_EightByteInt = &
@@ -783,7 +783,7 @@ function nf90_get_var_7D_EightByteInt(ncid, varid, values, start, count, stride,
         values(:, :, :, :, :, :, :) = reshape(defaultInt8Array(:), shapeValues)
         if (allocated(defaultInt8Array)) deallocate(defaultInt8Array)
      else
-        allocate(defaultIntArray(size(values)))
+        allocate(defaultIntArray(size(values,kind=EightByteInt)))
         if(present(map))  then
            localMap   (:size(map))    = map(:)
            nf90_get_var_7D_EightByteInt = &

--- a/fortran/netcdf_eightbyte.F90
+++ b/fortran/netcdf_eightbyte.F90
@@ -254,7 +254,7 @@
      integer                               :: numDims, counter, shapeValues(1)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -295,7 +295,7 @@
      integer                               :: numDims, counter, shapeValues(2)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -336,7 +336,7 @@
      integer                               :: numDims, counter, shapeValues(3)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -377,7 +377,7 @@
      integer                               :: numDims, counter, shapeValues(4)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -418,7 +418,7 @@
      integer                               :: numDims, counter, shapeValues(5)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -459,7 +459,7 @@
      integer                               :: numDims, counter, shapeValues(6)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -500,7 +500,7 @@
      integer                               :: numDims, counter, shapeValues(7)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)

--- a/fortran/netcdf_expanded.F90
+++ b/fortran/netcdf_expanded.F90
@@ -1888,7 +1888,7 @@
      integer                               :: numDims, counter, shapeValues(1)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -1929,7 +1929,7 @@
      integer                               :: numDims, counter, shapeValues(2)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -1970,7 +1970,7 @@
      integer                               :: numDims, counter, shapeValues(3)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -2011,7 +2011,7 @@
      integer                               :: numDims, counter, shapeValues(4)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -2052,7 +2052,7 @@
      integer                               :: numDims, counter, shapeValues(5)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -2093,7 +2093,7 @@
      integer                               :: numDims, counter, shapeValues(6)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)
@@ -2134,7 +2134,7 @@
      integer                               :: numDims, counter, shapeValues(7)
      integer, dimension(:), allocatable    :: defaultIntArray
 
-     allocate(defaultIntArray(size(values)))
+     allocate(defaultIntArray(size(values,kind=EightByteInt)))
 
      ! Set local arguments to default values
      shapeValues             = shape(values)


### PR DESCRIPTION
Refer to #476.  This PR might resolve the issue.

This is a straightforward PR, but it is untested.  Please run this through CI, or let me know how I can enable CI on my personal fork of netcdf-fortran.

This PR supports large array variables with aggregate size (total number of values [not bytes]) exceeding the original code limit of MAX_INT (2^31 - 1).

The original library code created temp arrays like this.  The original fortran 90 `size()` intrinsic function returned only 32-bit integers.  This overflowed and failed whenever the total number of elements (product of multiple dimensions) exceeded MAX_INT:
```
allocate(defaultIntArray(size(values)))
```
Fortran 2003+ allows 64-bit integers to be optionally specified for the `size()` intrinsic.  The array limit now becomes MAX_INT64 (2^63 - 1) total number of values:
```
allocate(defaultIntArray(size(values,kind=EightByteInt)))
```
This PR fixes all 28 instances of this `allocate` construction, across three different source files in the `fortran/` source directory.

This PR will require a minimum standard of fortran 2003 to build netcdf-fortran.  I do not know whether the current overall requirement has already reached fortran 2003.